### PR TITLE
feat: add `prefer-array-to-reversed` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ export default [
 | [prefer-array-at](./src/rules/prefer-array-at.ts) | Prefer `Array.prototype.at()` over length-based indexing | ✅ | ✅ |
 | [prefer-array-fill](./src/rules/prefer-array-fill.ts) | Prefer `Array.prototype.fill()` over `Array.from()` or `map()` with constant values | ✅ | ✅ |
 | [prefer-array-includes](./src/rules/prefer-array-includes.ts) | Prefer `Array.prototype.includes()` over `indexOf()` comparisons | ✅ | ✅ |
+| [prefer-array-to-reversed](./src/rules/prefer-array-to-reversed.ts) | Prefer `Array.prototype.toReversed()` over copying and reversing arrays | ✅ | ✅ |
 
 ### Module replacements
 

--- a/src/configs/modernization.ts
+++ b/src/configs/modernization.ts
@@ -7,6 +7,7 @@ export const modernization = (plugin: ESLint.Plugin): Linter.Config => ({
   rules: {
     'e18e/prefer-array-at': 'error',
     'e18e/prefer-array-fill': 'error',
-    'e18e/prefer-array-includes': 'error'
+    'e18e/prefer-array-includes': 'error',
+    'e18e/prefer-array-to-reversed': 'error'
   }
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import {performanceImprovements} from './configs/performance-improvements.js';
 import {preferArrayAt} from './rules/prefer-array-at.js';
 import {preferArrayFill} from './rules/prefer-array-fill.js';
 import {preferArrayIncludes} from './rules/prefer-array-includes.js';
+import {preferArrayToReversed} from './rules/prefer-array-to-reversed.js';
 import {rules as dependRules} from 'eslint-plugin-depend';
 
 const plugin: ESLint.Plugin = {
@@ -18,6 +19,7 @@ const plugin: ESLint.Plugin = {
     'prefer-array-at': preferArrayAt,
     'prefer-array-fill': preferArrayFill,
     'prefer-array-includes': preferArrayIncludes,
+    'prefer-array-to-reversed': preferArrayToReversed,
     ...dependRules
   }
 };

--- a/src/rules/prefer-array-to-reversed.test.ts
+++ b/src/rules/prefer-array-to-reversed.test.ts
@@ -1,0 +1,99 @@
+import {RuleTester} from 'eslint';
+import {preferArrayToReversed} from './prefer-array-to-reversed.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('prefer-array-to-reversed', preferArrayToReversed, {
+  valid: [
+    'const reversed = arr.reverse();',
+    'arr.reverse();',
+
+    // slice with non-zero argument
+    'const reversed = arr.slice(1).reverse();',
+    'const reversed = arr.slice(0, 5).reverse();',
+
+    // Already using toReversed
+    'const reversed = arr.toReversed();',
+
+    // reversing other results
+    'const filtered = arr.filter(x => x > 0).reverse();',
+    'const mapped = arr.map(x => x * 2).reverse();'
+  ],
+
+  invalid: [
+    // concat().reverse()
+    {
+      code: 'const reversed = arr.concat().reverse();',
+      output: 'const reversed = arr.toReversed();',
+      errors: [{messageId: 'preferToReversed', data: {array: 'arr'}}]
+    },
+
+    // slice().reverse()
+    {
+      code: 'const reversed = arr.slice().reverse();',
+      output: 'const reversed = arr.toReversed();',
+      errors: [{messageId: 'preferToReversed', data: {array: 'arr'}}]
+    },
+
+    // slice(0).reverse()
+    {
+      code: 'const reversed = arr.slice(0).reverse();',
+      output: 'const reversed = arr.toReversed();',
+      errors: [{messageId: 'preferToReversed', data: {array: 'arr'}}]
+    },
+
+    // [...array].reverse()
+    {
+      code: 'const reversed = [...arr].reverse();',
+      output: 'const reversed = arr.toReversed();',
+      errors: [{messageId: 'preferToReversed', data: {array: 'arr'}}]
+    },
+
+    // Member expressions
+    {
+      code: 'const reversed = obj.arr.concat().reverse();',
+      output: 'const reversed = obj.arr.toReversed();',
+      errors: [{messageId: 'preferToReversed', data: {array: 'obj.arr'}}]
+    },
+
+    // Member expressions with slice
+    {
+      code: 'const reversed = obj.arr.slice().reverse();',
+      output: 'const reversed = obj.arr.toReversed();',
+      errors: [{messageId: 'preferToReversed', data: {array: 'obj.arr'}}]
+    },
+
+    // Member expressions with spread
+    {
+      code: 'const reversed = [...obj.arr].reverse();',
+      output: 'const reversed = obj.arr.toReversed();',
+      errors: [{messageId: 'preferToReversed', data: {array: 'obj.arr'}}]
+    },
+
+    // Without assignment
+    {
+      code: 'arr.concat().reverse();',
+      output: 'arr.toReversed();',
+      errors: [{messageId: 'preferToReversed', data: {array: 'arr'}}]
+    },
+
+    // Nested in expressions
+    {
+      code: 'console.log(arr.slice().reverse());',
+      output: 'console.log(arr.toReversed());',
+      errors: [{messageId: 'preferToReversed', data: {array: 'arr'}}]
+    },
+
+    // Complex expressions
+    {
+      code: 'const result = someFunc().slice(0).reverse();',
+      output: 'const result = someFunc().toReversed();',
+      errors: [{messageId: 'preferToReversed', data: {array: 'someFunc()'}}]
+    }
+  ]
+});

--- a/src/rules/prefer-array-to-reversed.ts
+++ b/src/rules/prefer-array-to-reversed.ts
@@ -1,0 +1,105 @@
+import type {Rule} from 'eslint';
+import type {CallExpression} from 'estree';
+
+function isCopyCall(node: CallExpression): boolean {
+  if (
+    node.callee.type !== 'MemberExpression' ||
+    node.callee.property.type !== 'Identifier'
+  ) {
+    return false;
+  }
+
+  const methodName = node.callee.property.name;
+
+  if (
+    (methodName === 'concat' || methodName === 'slice') &&
+    node.arguments.length === 0
+  ) {
+    return true;
+  }
+
+  if (
+    methodName === 'slice' &&
+    node.arguments.length === 1 &&
+    node.arguments[0]?.type === 'Literal' &&
+    node.arguments[0].value === 0
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+export const preferArrayToReversed: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer Array.prototype.toReversed() over copying and reversing arrays',
+      recommended: true
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      preferToReversed:
+        'Use {{array}}.toReversed() instead of copying and reversing'
+    }
+  },
+  create(context) {
+    const sourceCode = context.sourceCode;
+
+    return {
+      CallExpression(node: CallExpression) {
+        if (
+          node.callee.type !== 'MemberExpression' ||
+          node.callee.property.type !== 'Identifier' ||
+          node.callee.property.name !== 'reverse'
+        ) {
+          return;
+        }
+
+        const reverseCallee = node.callee.object;
+
+        if (
+          reverseCallee.type === 'CallExpression' &&
+          isCopyCall(reverseCallee) &&
+          reverseCallee.callee.type === 'MemberExpression'
+        ) {
+          const arrayText = sourceCode.getText(reverseCallee.callee.object);
+
+          context.report({
+            node,
+            messageId: 'preferToReversed',
+            data: {
+              array: arrayText
+            },
+            fix(fixer) {
+              return fixer.replaceText(node, `${arrayText}.toReversed()`);
+            }
+          });
+          return;
+        }
+
+        if (
+          reverseCallee.type === 'ArrayExpression' &&
+          reverseCallee.elements.length === 1 &&
+          reverseCallee.elements[0]?.type === 'SpreadElement'
+        ) {
+          const spreadArg = reverseCallee.elements[0].argument;
+          const arrayText = sourceCode.getText(spreadArg);
+
+          context.report({
+            node,
+            messageId: 'preferToReversed',
+            data: {
+              array: arrayText
+            },
+            fix(fixer) {
+              return fixer.replaceText(node, `${arrayText}.toReversed()`);
+            }
+          });
+        }
+      }
+    };
+  }
+};


### PR DESCRIPTION
Adds a new `prefer-array-to-reversed` rule for preferring
`arr.toReversed()` rather than `arr.concat().reverse()`-like patterns.
