### PR TITLE
feat: rename `prefer-array-includes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ export default [
     rules: {
       'e18e/prefer-array-at': 'error',
       'e18e/prefer-array-fill': 'error',
-      'e18e/prefer-array-includes': 'error'
+      'e18e/prefer-includes': 'error'
     }
   }
 ];
@@ -61,7 +61,7 @@ export default [
 |------|-------------|-------------|---------|
 | [prefer-array-at](./src/rules/prefer-array-at.ts) | Prefer `Array.prototype.at()` over length-based indexing | ✅ | ✅ |
 | [prefer-array-fill](./src/rules/prefer-array-fill.ts) | Prefer `Array.prototype.fill()` over `Array.from()` or `map()` with constant values | ✅ | ✅ |
-| [prefer-array-includes](./src/rules/prefer-array-includes.ts) | Prefer `Array.prototype.includes()` over `indexOf()` comparisons | ✅ | ✅ |
+| [prefer-includes](./src/rules/prefer-includes.ts) | Prefer `.includes()` over `indexOf()` comparisons for arrays and strings | ✅ | ✅ |
 | [prefer-array-to-reversed](./src/rules/prefer-array-to-reversed.ts) | Prefer `Array.prototype.toReversed()` over copying and reversing arrays | ✅ | ✅ |
 
 ### Module replacements

--- a/src/configs/modernization.ts
+++ b/src/configs/modernization.ts
@@ -7,7 +7,7 @@ export const modernization = (plugin: ESLint.Plugin): Linter.Config => ({
   rules: {
     'e18e/prefer-array-at': 'error',
     'e18e/prefer-array-fill': 'error',
-    'e18e/prefer-array-includes': 'error',
+    'e18e/prefer-includes': 'error',
     'e18e/prefer-array-to-reversed': 'error'
   }
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import {moduleReplacements} from './configs/module-replacements.js';
 import {performanceImprovements} from './configs/performance-improvements.js';
 import {preferArrayAt} from './rules/prefer-array-at.js';
 import {preferArrayFill} from './rules/prefer-array-fill.js';
-import {preferArrayIncludes} from './rules/prefer-array-includes.js';
+import {preferIncludes} from './rules/prefer-includes.js';
 import {preferArrayToReversed} from './rules/prefer-array-to-reversed.js';
 import {rules as dependRules} from 'eslint-plugin-depend';
 
@@ -18,7 +18,7 @@ const plugin: ESLint.Plugin = {
   rules: {
     'prefer-array-at': preferArrayAt,
     'prefer-array-fill': preferArrayFill,
-    'prefer-array-includes': preferArrayIncludes,
+    'prefer-includes': preferIncludes,
     'prefer-array-to-reversed': preferArrayToReversed,
     ...dependRules
   }

--- a/src/rules/prefer-includes.test.ts
+++ b/src/rules/prefer-includes.test.ts
@@ -1,5 +1,5 @@
 import {RuleTester} from 'eslint';
-import {preferArrayIncludes} from './prefer-array-includes.js';
+import {preferIncludes} from './prefer-includes.js';
 
 const ruleTester = new RuleTester({
   languageOptions: {
@@ -8,7 +8,7 @@ const ruleTester = new RuleTester({
   }
 });
 
-ruleTester.run('prefer-array-includes', preferArrayIncludes, {
+ruleTester.run('prefer-includes', preferIncludes, {
   valid: [
     // Already using .includes()
     'if (arr.includes(item)) {}',

--- a/src/rules/prefer-includes.ts
+++ b/src/rules/prefer-includes.ts
@@ -135,12 +135,12 @@ function checkUnaryExpression(
   }
 }
 
-export const preferArrayIncludes: Rule.RuleModule = {
+export const preferIncludes: Rule.RuleModule = {
   meta: {
     type: 'suggestion',
     docs: {
       description:
-        'Prefer Array.prototype.includes() over indexOf() comparisons',
+        'Prefer .includes() over indexOf() comparisons for arrays and strings',
       recommended: true
     },
     fixable: 'code',


### PR DESCRIPTION
It applies to strings just the same, so let's unify!
