### PR TITLE
feat: add `prefer-exponentiation-operator` rule

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import {preferArrayAt} from './rules/prefer-array-at.js';
 import {preferArrayFill} from './rules/prefer-array-fill.js';
 import {preferIncludes} from './rules/prefer-includes.js';
 import {preferArrayToReversed} from './rules/prefer-array-to-reversed.js';
+import {preferExponentiationOperator} from './rules/prefer-exponentiation-operator.js';
 import {rules as dependRules} from 'eslint-plugin-depend';
 
 const plugin: ESLint.Plugin = {
@@ -20,6 +21,7 @@ const plugin: ESLint.Plugin = {
     'prefer-array-fill': preferArrayFill,
     'prefer-includes': preferIncludes,
     'prefer-array-to-reversed': preferArrayToReversed,
+    'prefer-exponentiation-operator': preferExponentiationOperator,
     ...dependRules
   }
 };

--- a/src/rules/prefer-exponentiation-operator.test.ts
+++ b/src/rules/prefer-exponentiation-operator.test.ts
@@ -1,0 +1,109 @@
+import {RuleTester} from 'eslint';
+import {preferExponentiationOperator} from './prefer-exponentiation-operator.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('prefer-exponentiation-operator', preferExponentiationOperator, {
+  valid: [
+    'const result = x ** y;',
+    'const squared = 2 ** 3;',
+
+    // Other Math methods
+    'const result = Math.sqrt(4);',
+    'const result = Math.floor(3.7);',
+
+    // different number of arguments
+    'const result = Math.pow(2);',
+    'const result = Math.pow(2, 3, 4);'
+  ],
+  invalid: [
+    {
+      code: 'const result = Math.pow(2, 3);',
+      output: 'const result = (2) ** (3);',
+      errors: [{messageId: 'preferExponentiation', line: 1, column: 16}]
+    },
+    {
+      code: 'const squared = Math.pow(x, 2);',
+      output: 'const squared = (x) ** (2);',
+      errors: [{messageId: 'preferExponentiation', line: 1, column: 17}]
+    },
+    {
+      code: 'const complex = Math.pow(base, exponent);',
+      output: 'const complex = (base) ** (exponent);',
+      errors: [{messageId: 'preferExponentiation', line: 1, column: 17}]
+    },
+
+    // nested calls
+    // RuleTester only applies one fix at a time FYI
+    {
+      code: 'const result = Math.pow(Math.pow(2, 3), 4);',
+      output: 'const result = (Math.pow(2, 3)) ** (4);',
+      errors: [
+        {messageId: 'preferExponentiation', line: 1, column: 16},
+        {messageId: 'preferExponentiation', line: 1, column: 25}
+      ]
+    },
+
+    // expressions
+    {
+      code: 'const result = Math.pow(a + b, c - d) * 2;',
+      output: 'const result = (a + b) ** (c - d) * 2;',
+      errors: [{messageId: 'preferExponentiation', line: 1, column: 16}]
+    },
+    {
+      code: 'const value = 10 + Math.pow(x, y);',
+      output: 'const value = 10 + (x) ** (y);',
+      errors: [{messageId: 'preferExponentiation', line: 1, column: 20}]
+    },
+
+    // Multiple calls in one statement
+    {
+      code: 'const result = Math.pow(a, 2) + Math.pow(b, 2);',
+      output: 'const result = (a) ** (2) + (b) ** (2);',
+      errors: [
+        {messageId: 'preferExponentiation', line: 1, column: 16},
+        {messageId: 'preferExponentiation', line: 1, column: 33}
+      ]
+    },
+
+    // complex expressions
+    {
+      code: 'const result = Math.pow(x * y, z / 2);',
+      output: 'const result = (x * y) ** (z / 2);',
+      errors: [{messageId: 'preferExponentiation', line: 1, column: 16}]
+    },
+
+    // function argument
+    {
+      code: 'console.log(Math.pow(2, 10));',
+      output: 'console.log((2) ** (10));',
+      errors: [{messageId: 'preferExponentiation', line: 1, column: 13}]
+    },
+
+    // return statement
+    {
+      code: 'function square(x) { return Math.pow(x, 2); }',
+      output: 'function square(x) { return (x) ** (2); }',
+      errors: [{messageId: 'preferExponentiation', line: 1, column: 29}]
+    },
+
+    // member expressions
+    {
+      code: 'const result = Math.pow(obj.value, arr[0]);',
+      output: 'const result = (obj.value) ** (arr[0]);',
+      errors: [{messageId: 'preferExponentiation', line: 1, column: 16}]
+    },
+
+    // function calls
+    {
+      code: 'const result = Math.pow(getValue(), getExponent());',
+      output: 'const result = (getValue()) ** (getExponent());',
+      errors: [{messageId: 'preferExponentiation', line: 1, column: 16}]
+    }
+  ]
+});

--- a/src/rules/prefer-exponentiation-operator.ts
+++ b/src/rules/prefer-exponentiation-operator.ts
@@ -1,0 +1,55 @@
+import type {Rule} from 'eslint';
+import type {CallExpression} from 'estree';
+
+export const preferExponentiationOperator: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Prefer the exponentiation operator ** over Math.pow()',
+      recommended: true
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      preferExponentiation: 'Use the ** operator instead of Math.pow()'
+    }
+  },
+  create(context) {
+    const sourceCode = context.sourceCode;
+
+    return {
+      CallExpression(node: CallExpression) {
+        if (
+          node.callee.type !== 'MemberExpression' ||
+          node.callee.object.type !== 'Identifier' ||
+          node.callee.object.name !== 'Math' ||
+          node.callee.property.type !== 'Identifier' ||
+          node.callee.property.name !== 'pow'
+        ) {
+          return;
+        }
+
+        const base = node.arguments[0];
+        const exponent = node.arguments[1];
+
+        if (!base || !exponent || node.arguments.length !== 2) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: 'preferExponentiation',
+          fix(fixer) {
+            const baseText = sourceCode.getText(base);
+            const exponentText = sourceCode.getText(exponent);
+
+            return fixer.replaceText(
+              node,
+              `(${baseText}) ** (${exponentText})`
+            );
+          }
+        });
+      }
+    };
+  }
+};


### PR DESCRIPTION
Prefers `a ** b` over `Math.pow(a, b)`.
