### PR TITLE
feat: add `prefer-array-to-sorted` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ export default [
 | [prefer-array-fill](./src/rules/prefer-array-fill.ts) | Prefer `Array.prototype.fill()` over `Array.from()` or `map()` with constant values | ✅ | ✅ |
 | [prefer-includes](./src/rules/prefer-includes.ts) | Prefer `.includes()` over `indexOf()` comparisons for arrays and strings | ✅ | ✅ |
 | [prefer-array-to-reversed](./src/rules/prefer-array-to-reversed.ts) | Prefer `Array.prototype.toReversed()` over copying and reversing arrays | ✅ | ✅ |
+| [prefer-array-to-sorted](./src/rules/prefer-array-to-sorted.ts) | Prefer `Array.prototype.toSorted()` over copying and sorting arrays | ✅ | ✅ |
 | [prefer-exponentiation-operator](./src/rules/prefer-exponentiation-operator.ts) | Prefer the exponentiation operator `**` over `Math.pow()` | ✅ | ✅ |
 | [prefer-object-has-own](./src/rules/prefer-object-has-own.ts) | Prefer `Object.hasOwn()` over `Object.prototype.hasOwnProperty.call()` and `obj.hasOwnProperty()` | ✅ | ✅ |
 

--- a/src/configs/modernization.ts
+++ b/src/configs/modernization.ts
@@ -9,6 +9,7 @@ export const modernization = (plugin: ESLint.Plugin): Linter.Config => ({
     'e18e/prefer-array-fill': 'error',
     'e18e/prefer-includes': 'error',
     'e18e/prefer-array-to-reversed': 'error',
+    'e18e/prefer-array-to-sorted': 'error',
     'e18e/prefer-object-has-own': 'error'
   }
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import {preferArrayAt} from './rules/prefer-array-at.js';
 import {preferArrayFill} from './rules/prefer-array-fill.js';
 import {preferIncludes} from './rules/prefer-includes.js';
 import {preferArrayToReversed} from './rules/prefer-array-to-reversed.js';
+import {preferArrayToSorted} from './rules/prefer-array-to-sorted.js';
 import {preferExponentiationOperator} from './rules/prefer-exponentiation-operator.js';
 import {preferObjectHasOwn} from './rules/prefer-object-has-own.js';
 import {rules as dependRules} from 'eslint-plugin-depend';
@@ -22,6 +23,7 @@ const plugin: ESLint.Plugin = {
     'prefer-array-fill': preferArrayFill,
     'prefer-includes': preferIncludes,
     'prefer-array-to-reversed': preferArrayToReversed,
+    'prefer-array-to-sorted': preferArrayToSorted,
     'prefer-exponentiation-operator': preferExponentiationOperator,
     'prefer-object-has-own': preferObjectHasOwn,
     ...dependRules

--- a/src/rules/prefer-array-to-reversed.ts
+++ b/src/rules/prefer-array-to-reversed.ts
@@ -1,34 +1,6 @@
 import type {Rule} from 'eslint';
 import type {CallExpression} from 'estree';
-
-function isCopyCall(node: CallExpression): boolean {
-  if (
-    node.callee.type !== 'MemberExpression' ||
-    node.callee.property.type !== 'Identifier'
-  ) {
-    return false;
-  }
-
-  const methodName = node.callee.property.name;
-
-  if (
-    (methodName === 'concat' || methodName === 'slice') &&
-    node.arguments.length === 0
-  ) {
-    return true;
-  }
-
-  if (
-    methodName === 'slice' &&
-    node.arguments.length === 1 &&
-    node.arguments[0]?.type === 'Literal' &&
-    node.arguments[0].value === 0
-  ) {
-    return true;
-  }
-
-  return false;
-}
+import {isCopyCall} from '../utils/ast.js';
 
 export const preferArrayToReversed: Rule.RuleModule = {
   meta: {

--- a/src/rules/prefer-array-to-sorted.test.ts
+++ b/src/rules/prefer-array-to-sorted.test.ts
@@ -1,0 +1,171 @@
+import {RuleTester} from 'eslint';
+import {preferArrayToSorted} from './prefer-array-to-sorted.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('prefer-array-to-sorted', preferArrayToSorted, {
+  valid: [
+    'const sorted = arr.sort();',
+    'arr.sort((a, b) => a - b);',
+
+    // Other array methods
+    'const mapped = arr.map(x => x * 2);',
+    'const arr = [1, 2, 3];',
+
+    // slice with different arguments
+    'arr.slice(1).sort();',
+    'arr.slice(0, 5).sort();'
+  ],
+
+  invalid: [
+    // concat().sort()
+    {
+      code: 'const sorted = arr.concat().sort((a, b) => a - b);',
+      output: 'const sorted = arr.toSorted((a, b) => a - b);',
+      errors: [
+        {
+          messageId: 'preferToSorted',
+          data: {array: 'arr'},
+          line: 1,
+          column: 16
+        }
+      ]
+    },
+    {
+      code: 'const sorted = arr.concat().sort();',
+      output: 'const sorted = arr.toSorted();',
+      errors: [
+        {
+          messageId: 'preferToSorted',
+          data: {array: 'arr'},
+          line: 1,
+          column: 16
+        }
+      ]
+    },
+
+    // slice().sort()
+    {
+      code: 'const sorted = arr.slice().sort();',
+      output: 'const sorted = arr.toSorted();',
+      errors: [
+        {
+          messageId: 'preferToSorted',
+          data: {array: 'arr'},
+          line: 1,
+          column: 16
+        }
+      ]
+    },
+    {
+      code: 'const sorted = myArray.slice().sort((a, b) => b - a);',
+      output: 'const sorted = myArray.toSorted((a, b) => b - a);',
+      errors: [
+        {
+          messageId: 'preferToSorted',
+          data: {array: 'myArray'},
+          line: 1,
+          column: 16
+        }
+      ]
+    },
+
+    // slice(0).sort()
+    {
+      code: 'const sorted = arr.slice(0).sort((a, b) => b - a);',
+      output: 'const sorted = arr.toSorted((a, b) => b - a);',
+      errors: [
+        {
+          messageId: 'preferToSorted',
+          data: {array: 'arr'},
+          line: 1,
+          column: 16
+        }
+      ]
+    },
+    {
+      code: 'const sorted = arr.slice(0).sort();',
+      output: 'const sorted = arr.toSorted();',
+      errors: [
+        {
+          messageId: 'preferToSorted',
+          data: {array: 'arr'},
+          line: 1,
+          column: 16
+        }
+      ]
+    },
+
+    // [...arr].sort()
+    {
+      code: 'const sorted = [...arr].sort();',
+      output: 'const sorted = arr.toSorted();',
+      errors: [
+        {
+          messageId: 'preferToSorted',
+          data: {array: 'arr'},
+          line: 1,
+          column: 16
+        }
+      ]
+    },
+    {
+      code: 'const sorted = [...myArray].sort((a, b) => a - b);',
+      output: 'const sorted = myArray.toSorted((a, b) => a - b);',
+      errors: [
+        {
+          messageId: 'preferToSorted',
+          data: {array: 'myArray'},
+          line: 1,
+          column: 16
+        }
+      ]
+    },
+
+    // Complex expressions
+    {
+      code: 'const sorted = obj.data.items.slice().sort();',
+      output: 'const sorted = obj.data.items.toSorted();',
+      errors: [
+        {
+          messageId: 'preferToSorted',
+          data: {array: 'obj.data.items'},
+          line: 1,
+          column: 16
+        }
+      ]
+    },
+    {
+      code: 'function foo() { return [...this.items].sort((a, b) => a.id - b.id); }',
+      output:
+        'function foo() { return this.items.toSorted((a, b) => a.id - b.id); }',
+      errors: [
+        {
+          messageId: 'preferToSorted',
+          data: {array: 'this.items'},
+          line: 1,
+          column: 25
+        }
+      ]
+    },
+
+    // Multiple arguments (edge case - sort() typically takes 0 or 1 arg)
+    {
+      code: 'const sorted = arr.slice().sort(arg1, arg2);',
+      output: 'const sorted = arr.toSorted(arg1, arg2);',
+      errors: [
+        {
+          messageId: 'preferToSorted',
+          data: {array: 'arr'},
+          line: 1,
+          column: 16
+        }
+      ]
+    }
+  ]
+});

--- a/src/rules/prefer-array-to-sorted.ts
+++ b/src/rules/prefer-array-to-sorted.ts
@@ -1,0 +1,93 @@
+import type {Rule} from 'eslint';
+import type {CallExpression} from 'estree';
+import {isCopyCall} from '../utils/ast.js';
+
+export const preferArrayToSorted: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer Array.prototype.toSorted() over copying and sorting arrays',
+      recommended: true
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      preferToSorted: 'Use {{array}}.toSorted() instead of copying and sorting'
+    }
+  },
+  create(context) {
+    const sourceCode = context.sourceCode;
+
+    return {
+      CallExpression(node: CallExpression) {
+        if (
+          node.callee.type !== 'MemberExpression' ||
+          node.callee.property.type !== 'Identifier' ||
+          node.callee.property.name !== 'sort'
+        ) {
+          return;
+        }
+
+        const sortCallee = node.callee.object;
+
+        if (
+          sortCallee.type === 'CallExpression' &&
+          isCopyCall(sortCallee) &&
+          sortCallee.callee.type === 'MemberExpression'
+        ) {
+          const arrayNode = sortCallee.callee.object;
+          const arrayText = sourceCode.getText(arrayNode);
+          const sortArgs = node.arguments;
+          const argsText =
+            sortArgs.length > 0
+              ? sortArgs.map((arg) => sourceCode.getText(arg)).join(', ')
+              : '';
+
+          context.report({
+            node,
+            messageId: 'preferToSorted',
+            data: {
+              array: arrayText
+            },
+            fix(fixer) {
+              return fixer.replaceText(
+                node,
+                `${arrayText}.toSorted(${argsText})`
+              );
+            }
+          });
+          return;
+        }
+
+        if (
+          sortCallee.type === 'ArrayExpression' &&
+          sortCallee.elements.length === 1 &&
+          sortCallee.elements[0]?.type === 'SpreadElement'
+        ) {
+          const spreadArg = sortCallee.elements[0].argument;
+          const arrayText = sourceCode.getText(spreadArg);
+          const sortArgs = node.arguments;
+          const argsText =
+            sortArgs.length > 0
+              ? sortArgs.map((arg) => sourceCode.getText(arg)).join(', ')
+              : '';
+
+          context.report({
+            node,
+            messageId: 'preferToSorted',
+            data: {
+              array: arrayText
+            },
+            fix(fixer) {
+              return fixer.replaceText(
+                node,
+                `${arrayText}.toSorted(${argsText})`
+              );
+            }
+          });
+        }
+      }
+    };
+  }
+};

--- a/src/utils/ast.ts
+++ b/src/utils/ast.ts
@@ -1,0 +1,34 @@
+import type {CallExpression} from 'estree';
+
+/**
+ * Checks if a CallExpression is a copy operation that creates a shallow copy of an array.
+ * Matches: concat(), slice(), slice(0)
+ */
+export function isCopyCall(node: CallExpression): boolean {
+  if (
+    node.callee.type !== 'MemberExpression' ||
+    node.callee.property.type !== 'Identifier'
+  ) {
+    return false;
+  }
+
+  const methodName = node.callee.property.name;
+
+  if (
+    (methodName === 'concat' || methodName === 'slice') &&
+    node.arguments.length === 0
+  ) {
+    return true;
+  }
+
+  if (
+    methodName === 'slice' &&
+    node.arguments.length === 1 &&
+    node.arguments[0]?.type === 'Literal' &&
+    node.arguments[0].value === 0
+  ) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
Prefers `toSorted` over `.slice().sort()`.
