### PR TITLE
feat: add `prefer-spread-syntax` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ export default [
 | [prefer-array-to-spliced](./src/rules/prefer-array-to-spliced.ts) | Prefer `Array.prototype.toSpliced()` over copying and splicing arrays | ✅ | ✅ |
 | [prefer-exponentiation-operator](./src/rules/prefer-exponentiation-operator.ts) | Prefer the exponentiation operator `**` over `Math.pow()` | ✅ | ✅ |
 | [prefer-object-has-own](./src/rules/prefer-object-has-own.ts) | Prefer `Object.hasOwn()` over `Object.prototype.hasOwnProperty.call()` and `obj.hasOwnProperty()` | ✅ | ✅ |
+| [prefer-spread-syntax](./src/rules/prefer-spread-syntax.ts) | Prefer spread syntax over `Array.concat()`, `Object.assign({}, ...)`, and `Function.apply()` | ✅ | ✅ |
 
 ### Module replacements
 

--- a/src/configs/modernization.ts
+++ b/src/configs/modernization.ts
@@ -11,6 +11,7 @@ export const modernization = (plugin: ESLint.Plugin): Linter.Config => ({
     'e18e/prefer-array-to-reversed': 'error',
     'e18e/prefer-array-to-sorted': 'error',
     'e18e/prefer-array-to-spliced': 'error',
-    'e18e/prefer-object-has-own': 'error'
+    'e18e/prefer-object-has-own': 'error',
+    'e18e/prefer-spread-syntax': 'error'
   }
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import {preferArrayToSorted} from './rules/prefer-array-to-sorted.js';
 import {preferArrayToSpliced} from './rules/prefer-array-to-spliced.js';
 import {preferExponentiationOperator} from './rules/prefer-exponentiation-operator.js';
 import {preferObjectHasOwn} from './rules/prefer-object-has-own.js';
+import {preferSpreadSyntax} from './rules/prefer-spread-syntax.js';
 import {rules as dependRules} from 'eslint-plugin-depend';
 
 const plugin: ESLint.Plugin = {
@@ -28,6 +29,7 @@ const plugin: ESLint.Plugin = {
     'prefer-array-to-spliced': preferArrayToSpliced,
     'prefer-exponentiation-operator': preferExponentiationOperator,
     'prefer-object-has-own': preferObjectHasOwn,
+    'prefer-spread-syntax': preferSpreadSyntax,
     ...dependRules
   }
 };

--- a/src/rules/prefer-spread-syntax.test.ts
+++ b/src/rules/prefer-spread-syntax.test.ts
@@ -1,0 +1,233 @@
+import {RuleTester} from 'eslint';
+import {preferSpreadSyntax} from './prefer-spread-syntax.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('prefer-spread-syntax', preferSpreadSyntax, {
+  valid: [
+    'const combined = [...arr, ...other];',
+    'const merged = {...obj1, ...obj2};',
+    'const result = fn(...args);',
+
+    // concat with no arguments
+    'arr.concat();',
+
+    // Object.assign with non-literal first argument
+    'Object.assign(target, source);',
+    'Object.assign(getTarget(), source);',
+
+    // Object.assign with __proto__
+    'Object.assign({__proto__: null}, obj);',
+    'Object.assign({__proto__: proto, foo: 1}, obj);',
+
+    // apply with context
+    'fn.apply(context, args);',
+    'obj.method.apply(obj, args);',
+
+    // apply with only one argument
+    'fn.apply(null);'
+  ],
+
+  invalid: [
+    // Array concat single argument
+    {
+      code: 'const combined = arr.concat(other);',
+      output: 'const combined = [...arr, ...other];',
+      errors: [
+        {
+          messageId: 'preferSpreadArray',
+          line: 1,
+          column: 18
+        }
+      ]
+    },
+
+    // Array concat multiple arguments
+    {
+      code: 'const multi = arr.concat(a, b, c);',
+      output: 'const multi = [...arr, ...a, ...b, ...c];',
+      errors: [
+        {
+          messageId: 'preferSpreadArray',
+          line: 1,
+          column: 15
+        }
+      ]
+    },
+
+    // Array concat with array literal
+    {
+      code: 'const result = arr.concat([1, 2, 3]);',
+      output: 'const result = [...arr, ...[1, 2, 3]];',
+      errors: [
+        {
+          messageId: 'preferSpreadArray',
+          line: 1,
+          column: 16
+        }
+      ]
+    },
+
+    // Array concat chained expression
+    {
+      code: 'const result = [1, 2].concat([3, 4]);',
+      output: 'const result = [...[1, 2], ...[3, 4]];',
+      errors: [
+        {
+          messageId: 'preferSpreadArray',
+          line: 1,
+          column: 16
+        }
+      ]
+    },
+
+    // Object.assign three arguments
+    {
+      code: 'const triple = Object.assign({}, a, b, c);',
+      output: 'const triple = {...a, ...b, ...c};',
+      errors: [
+        {
+          messageId: 'preferSpreadObject',
+          line: 1,
+          column: 16
+        }
+      ]
+    },
+
+    // Object.assign non-empty object literal (single property)
+    {
+      code: 'const merged = Object.assign({foo: 1}, obj);',
+      output: 'const merged = {foo: 1, ...obj};',
+      errors: [
+        {
+          messageId: 'preferSpreadObject',
+          line: 1,
+          column: 16
+        }
+      ]
+    },
+
+    // Object.assign non-empty object literal (multiple properties)
+    {
+      code: 'const merged = Object.assign({foo: 1, bar: 2}, a, b);',
+      output: 'const merged = {foo: 1, bar: 2, ...a, ...b};',
+      errors: [
+        {
+          messageId: 'preferSpreadObject',
+          line: 1,
+          column: 16
+        }
+      ]
+    },
+
+    // Object.assign non-empty with shorthand property
+    {
+      code: 'const merged = Object.assign({foo}, obj);',
+      output: 'const merged = {foo, ...obj};',
+      errors: [
+        {
+          messageId: 'preferSpreadObject',
+          line: 1,
+          column: 16
+        }
+      ]
+    },
+
+    // Object.assign non-empty with computed property
+    {
+      code: 'const merged = Object.assign({[key]: value}, obj);',
+      output: 'const merged = {[key]: value, ...obj};',
+      errors: [
+        {
+          messageId: 'preferSpreadObject',
+          line: 1,
+          column: 16
+        }
+      ]
+    },
+
+    // Object.assign non-empty with quoted __proto__ is safe
+    {
+      code: 'const merged = Object.assign({"__proto__": null}, obj);',
+      output: 'const merged = {"__proto__": null, ...obj};',
+      errors: [
+        {
+          messageId: 'preferSpreadObject',
+          line: 1,
+          column: 16
+        }
+      ]
+    },
+
+    // Function.apply with null
+    {
+      code: 'const result = fn.apply(null, args);',
+      output: 'const result = fn(...args);',
+      errors: [
+        {
+          messageId: 'preferSpreadFunction',
+          line: 1,
+          column: 16
+        }
+      ]
+    },
+
+    // Function.apply with undefined
+    {
+      code: 'const result = fn.apply(undefined, args);',
+      output: 'const result = fn(...args);',
+      errors: [
+        {
+          messageId: 'preferSpreadFunction',
+          line: 1,
+          column: 16
+        }
+      ]
+    },
+
+    // Function.apply Math.max
+    {
+      code: 'const max = Math.max.apply(null, numbers);',
+      output: 'const max = Math.max(...numbers);',
+      errors: [
+        {
+          messageId: 'preferSpreadFunction',
+          line: 1,
+          column: 13
+        }
+      ]
+    },
+
+    // Multiple issues in one file
+    {
+      code: `const arr = [1, 2].concat([3, 4]);
+const obj = Object.assign({}, {a: 1}, {b: 2});
+const max = Math.max.apply(null, numbers);`,
+      output: `const arr = [...[1, 2], ...[3, 4]];
+const obj = {...{a: 1}, ...{b: 2}};
+const max = Math.max(...numbers);`,
+      errors: [
+        {
+          messageId: 'preferSpreadArray',
+          line: 1,
+          column: 13
+        },
+        {
+          messageId: 'preferSpreadObject',
+          line: 2,
+          column: 13
+        },
+        {
+          messageId: 'preferSpreadFunction',
+          line: 3,
+          column: 13
+        }
+      ]
+    }
+  ]
+});

--- a/src/rules/prefer-spread-syntax.ts
+++ b/src/rules/prefer-spread-syntax.ts
@@ -1,0 +1,124 @@
+import type {Rule} from 'eslint';
+import type {CallExpression, Expression} from 'estree';
+
+function isNullOrUndefined(node: Expression): boolean {
+  if (node.type === 'Literal' && node.value === null) {
+    return true;
+  }
+  return node.type === 'Identifier' && node.name === 'undefined';
+}
+
+export const preferSpreadSyntax: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer spread syntax over Array.concat(), Object.assign({}, ...), and Function.apply()',
+      recommended: true
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      preferSpreadArray:
+        'Use spread syntax [...arr, ...other] instead of arr.concat(other)',
+      preferSpreadObject:
+        'Use spread syntax {...a, ...b} instead of Object.assign({}, a, b)',
+      preferSpreadFunction:
+        'Use spread syntax fn(...args) instead of fn.apply(null/undefined, args)'
+    }
+  },
+  create(context) {
+    const sourceCode = context.sourceCode;
+
+    return {
+      CallExpression(node: CallExpression) {
+        if (node.callee.type !== 'MemberExpression') {
+          return;
+        }
+
+        let messageId: string | undefined;
+        let replacement: string | undefined;
+
+        // array.concat()
+        if (
+          node.callee.property.type === 'Identifier' &&
+          node.callee.property.name === 'concat' &&
+          node.arguments.length > 0
+        ) {
+          const arrayText = sourceCode.getText(node.callee.object);
+          const argTexts = node.arguments.map((arg) => sourceCode.getText(arg));
+          const spreadParts = [arrayText, ...argTexts]
+            .map((part) => `...${part}`)
+            .join(', ');
+          replacement = `[${spreadParts}]`;
+          messageId = 'preferSpreadArray';
+        }
+        // Object.assign({...}, ...)
+        else if (
+          node.callee.object.type === 'Identifier' &&
+          node.callee.object.name === 'Object' &&
+          node.callee.property.type === 'Identifier' &&
+          node.callee.property.name === 'assign' &&
+          node.arguments.length >= 2
+        ) {
+          const firstArg = node.arguments[0]!;
+          if (
+            firstArg.type !== 'SpreadElement' &&
+            firstArg.type === 'ObjectExpression'
+          ) {
+            const hasUnquotedProto = firstArg.properties.some(
+              (prop) =>
+                prop.type === 'Property' &&
+                !prop.computed &&
+                prop.key.type === 'Identifier' &&
+                prop.key.name === '__proto__'
+            );
+
+            if (!hasUnquotedProto) {
+              const spreadArgs = node.arguments
+                .slice(1)
+                .map((arg) => `...${sourceCode.getText(arg)}`)
+                .join(', ');
+
+              if (firstArg.properties.length === 0) {
+                replacement = `{${spreadArgs}}`;
+              } else {
+                const literalText = sourceCode.getText(firstArg);
+                const innerContent = literalText.slice(1, -1); // Remove { and }
+                replacement = `{${innerContent}, ${spreadArgs}}`;
+              }
+              messageId = 'preferSpreadObject';
+            }
+          }
+        }
+        // function.apply(null/undefined, args)
+        else if (
+          node.callee.property.type === 'Identifier' &&
+          node.callee.property.name === 'apply' &&
+          node.arguments.length === 2
+        ) {
+          const firstArg = node.arguments[0]!;
+          if (
+            firstArg.type !== 'SpreadElement' &&
+            isNullOrUndefined(firstArg)
+          ) {
+            const fnText = sourceCode.getText(node.callee.object);
+            const argsText = sourceCode.getText(node.arguments[1]!);
+            replacement = `${fnText}(...${argsText})`;
+            messageId = 'preferSpreadFunction';
+          }
+        }
+
+        if (messageId && replacement) {
+          context.report({
+            node,
+            messageId,
+            fix(fixer) {
+              return fixer.replaceText(node, replacement);
+            }
+          });
+        }
+      }
+    };
+  }
+};


### PR DESCRIPTION
Prefers `[...iter]` over `Object.assign({}, iter)`, and similar
patterns.
