### PR TITLE
feat: add `prefer-timer-args` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ export default [
 | Rule | Description | Recommended | Fixable | Requires Types |
 |------|-------------|-------------|---------|----------------|
 | [no-indexof-equality](./src/rules/no-indexof-equality.ts) | Prefer `startsWith()` for strings and direct array access over `indexOf()` equality checks | ✖️ | ✅ | ✅ |
+| [prefer-timer-args](./src/rules/prefer-timer-args.ts) | Prefer passing function and arguments directly to `setTimeout`/`setInterval` instead of wrapping in an arrow function or using `bind` | ✅ | ✅ | ✖️ |
 
 ## License
 

--- a/src/configs/performance-improvements.ts
+++ b/src/configs/performance-improvements.ts
@@ -6,5 +6,7 @@ export const performanceImprovements = (
   plugins: {
     e18e: plugin
   },
-  rules: {}
+  rules: {
+    'e18e/prefer-timer-args': 'error'
+  }
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import {preferObjectHasOwn} from './rules/prefer-object-has-own.js';
 import {preferSpreadSyntax} from './rules/prefer-spread-syntax.js';
 import {preferUrlCanParse} from './rules/prefer-url-canparse.js';
 import {noIndexOfEquality} from './rules/no-indexof-equality.js';
+import {preferTimerArgs} from './rules/prefer-timer-args.js';
 import {rules as dependRules} from 'eslint-plugin-depend';
 
 const plugin: ESLint.Plugin = {
@@ -36,6 +37,7 @@ const plugin: ESLint.Plugin = {
     'prefer-spread-syntax': preferSpreadSyntax,
     'prefer-url-canparse': preferUrlCanParse,
     'no-indexof-equality': noIndexOfEquality,
+    'prefer-timer-args': preferTimerArgs,
     ...dependRules
   }
 };

--- a/src/rules/prefer-timer-args.test.ts
+++ b/src/rules/prefer-timer-args.test.ts
@@ -1,0 +1,436 @@
+import {RuleTester} from 'eslint';
+import {preferTimerArgs} from './prefer-timer-args.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('prefer-timer-args', preferTimerArgs, {
+  valid: [
+    // Already using timer args correctly
+    'setTimeout(doSomething, 100)',
+    'setTimeout(doSomething, 100, a, b)',
+
+    // Arrow functions with block bodies (multiple statements or return)
+    'setTimeout(() => { doSomething(a, b); }, 100)',
+    'setTimeout(() => { console.log("hi"); doSomething(); }, 100)',
+    'setTimeout(() => { return doSomething(a); }, 100)',
+
+    // Arrow functions with parameters
+    'setTimeout((x) => doSomething(x), 100)',
+
+    // Function expressions
+    'setTimeout(function() { doSomething(); }, 100)',
+
+    // Non-timer calls
+    'requestAnimationFrame(() => render())',
+
+    // Arrow function body is not a call expression
+    'setTimeout(() => a + b, 100)',
+    'setTimeout(() => obj.prop, 100)',
+
+    // bind() with non-null/undefined context (skipped, could change behavior)
+    'setTimeout(fn.bind(this, a, b), 100)',
+    'setTimeout(fn.bind(obj, a, b), 100)',
+
+    // bind() with no arguments
+    'setTimeout(fn.bind(), 100)',
+
+    // Non-bind method calls
+    'setTimeout(fn.call(null, a, b), 100)',
+    'setTimeout(fn.apply(null, args), 100)',
+
+    // Unsafe transformations - arguments contain call expressions
+    'setTimeout(() => fn(getData()), 100)',
+    'setTimeout(() => fn(obj.method()), 100)',
+    'setTimeout(() => fn(a + getData()), 100)',
+    'setTimeout(() => fn([getData()]), 100)',
+    'setTimeout(() => fn({key: getData()}), 100)',
+    'setTimeout(fn.bind(null, getData()), 100)',
+
+    // window.setTimeout examples
+    'window.setTimeout(doSomething, 100)',
+    'window.setTimeout(() => { doSomething(a); }, 100)',
+    'window.setTimeout((x) => doSomething(x), 100)',
+    'window.setTimeout(fn.bind(this, a), 100)',
+
+    // globalThis.setTimeout examples
+    'globalThis.setTimeout(doSomething, 100, a, b)',
+    'globalThis.setTimeout(() => { doSomething(a); }, 100)',
+    'globalThis.setTimeout(fn.bind(this, a), 100)',
+
+    // setInterval examples
+    'setInterval(doSomething, 100)',
+    'setInterval(() => { doSomething(a); }, 100)',
+    'setInterval((x) => doSomething(x), 100)',
+    'setInterval(fn.bind(this, a), 100)',
+    'setInterval(() => fn(getData()), 100)',
+    'window.setInterval(() => { fn(a); }, 100)',
+    'globalThis.setInterval(fn.bind(obj, a), 100)',
+
+    // Edge cases
+    'setTimeout()',
+    'setTimeout(() => fn())',
+    'notSetTimeout(() => doSomething(a), 100)'
+  ],
+
+  invalid: [
+    // Basic case
+    {
+      code: 'setTimeout(() => doSomething(a, b), 100)',
+      output: 'setTimeout(doSomething, 100, a, b)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // No arguments to the inner function
+    {
+      code: 'setTimeout(() => doSomething(), 100)',
+      output: 'setTimeout(doSomething, 100)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // Single argument
+    {
+      code: 'setTimeout(() => fn(x), 1000)',
+      output: 'setTimeout(fn, 1000, x)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // Multiple arguments
+    {
+      code: 'setTimeout(() => process(a, b, c), 0)',
+      output: 'setTimeout(process, 0, a, b, c)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // Method calls
+    {
+      code: 'setTimeout(() => obj.method(arg), 100)',
+      output: 'setTimeout(obj.method, 100, arg)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // Nested property access
+    {
+      code: 'setTimeout(() => this.handler.process(data), 500)',
+      output: 'setTimeout(this.handler.process, 500, data)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // Complex expressions as arguments (safe - no calls)
+    {
+      code: 'setTimeout(() => fn(a + b, c * d), 100)',
+      output: 'setTimeout(fn, 100, a + b, c * d)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // Multiple occurrences
+    {
+      code: `setTimeout(() => fn1(a), 100);
+setTimeout(() => fn2(b, c), 200);`,
+      output: `setTimeout(fn1, 100, a);
+setTimeout(fn2, 200, b, c);`,
+      errors: [
+        {
+          messageId: 'preferArgs'
+        },
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // In different contexts
+    {
+      code: 'const timer = setTimeout(() => cleanup(resource), 5000)',
+      output: 'const timer = setTimeout(cleanup, 5000, resource)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // With spread arguments in the inner call
+    {
+      code: 'setTimeout(() => fn(...args), 100)',
+      output: 'setTimeout(fn, 100, ...args)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // Chained method calls
+    {
+      code: 'setTimeout(() => arr.filter(fn).map(transform), 100)',
+      output: 'setTimeout(arr.filter(fn).map, 100, transform)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // bind() with null context
+    {
+      code: 'setTimeout(fn.bind(null, a, b), 100)',
+      output: 'setTimeout(fn, 100, a, b)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // bind() with undefined context
+    {
+      code: 'setTimeout(fn.bind(undefined, x), 200)',
+      output: 'setTimeout(fn, 200, x)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // bind() with null and multiple arguments
+    {
+      code: 'setTimeout(process.bind(null, arg1, arg2, arg3), 500)',
+      output: 'setTimeout(process, 500, arg1, arg2, arg3)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // bind() with undefined and no additional arguments
+    {
+      code: 'setTimeout(doSomething.bind(undefined), 1000)',
+      output: 'setTimeout(doSomething, 1000)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // bind() on method with null context
+    {
+      code: 'setTimeout(obj.method.bind(null, arg), 100)',
+      output: 'setTimeout(obj.method, 100, arg)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // bind() with null in complex expression
+    {
+      code: 'const timer = setTimeout(handler.bind(null, event, data), 0)',
+      output: 'const timer = setTimeout(handler, 0, event, data)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // Multiple occurrences with mixed patterns
+    {
+      code: `setTimeout(() => fn1(a), 100);
+setTimeout(fn2.bind(null, b, c), 200);`,
+      output: `setTimeout(fn1, 100, a);
+setTimeout(fn2, 200, b, c);`,
+      errors: [
+        {
+          messageId: 'preferArgs'
+        },
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // window.setTimeout with arrow function
+    {
+      code: 'window.setTimeout(() => doSomething(a, b), 100)',
+      output: 'window.setTimeout(doSomething, 100, a, b)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // window.setTimeout with no arguments
+    {
+      code: 'window.setTimeout(() => fn(), 1000)',
+      output: 'window.setTimeout(fn, 1000)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // window.setTimeout with bind(null)
+    {
+      code: 'window.setTimeout(fn.bind(null, arg1, arg2), 500)',
+      output: 'window.setTimeout(fn, 500, arg1, arg2)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // window.setTimeout with bind(undefined)
+    {
+      code: 'window.setTimeout(handler.bind(undefined, data), 0)',
+      output: 'window.setTimeout(handler, 0, data)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // globalThis.setTimeout with arrow function
+    {
+      code: 'globalThis.setTimeout(() => doSomething(a, b), 100)',
+      output: 'globalThis.setTimeout(doSomething, 100, a, b)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // globalThis.setTimeout with bind(null)
+    {
+      code: 'globalThis.setTimeout(fn.bind(null, arg1, arg2), 500)',
+      output: 'globalThis.setTimeout(fn, 500, arg1, arg2)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // Multiple matches with different setTimeout variants
+    {
+      code: `setTimeout(() => fn1(a), 100);
+window.setTimeout(fn2.bind(null, b), 200);
+globalThis.setTimeout(() => fn3(c), 300);`,
+      output: `setTimeout(fn1, 100, a);
+window.setTimeout(fn2, 200, b);
+globalThis.setTimeout(fn3, 300, c);`,
+      errors: [
+        {
+          messageId: 'preferArgs'
+        },
+        {
+          messageId: 'preferArgs'
+        },
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // setInterval with arrow function
+    {
+      code: 'setInterval(() => doSomething(a, b), 100)',
+      output: 'setInterval(doSomething, 100, a, b)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // setInterval with bind(null)
+    {
+      code: 'setInterval(fn.bind(null, arg1, arg2), 500)',
+      output: 'setInterval(fn, 500, arg1, arg2)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // window.setInterval
+    {
+      code: 'window.setInterval(() => fn(x), 1000)',
+      output: 'window.setInterval(fn, 1000, x)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // globalThis.setInterval
+    {
+      code: 'globalThis.setInterval(() => process(data), 100)',
+      output: 'globalThis.setInterval(process, 100, data)',
+      errors: [
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    },
+
+    // Mixed setTimeout and setInterval
+    {
+      code: `setTimeout(() => fn1(a), 100);
+setInterval(() => fn2(b), 200);`,
+      output: `setTimeout(fn1, 100, a);
+setInterval(fn2, 200, b);`,
+      errors: [
+        {
+          messageId: 'preferArgs'
+        },
+        {
+          messageId: 'preferArgs'
+        }
+      ]
+    }
+  ]
+});

--- a/src/rules/prefer-timer-args.ts
+++ b/src/rules/prefer-timer-args.ts
@@ -1,0 +1,225 @@
+import type {Rule} from 'eslint';
+import type {
+  CallExpression,
+  ArrowFunctionExpression,
+  Expression,
+  SpreadElement
+} from 'estree';
+
+function isNullOrUndefined(node: Expression): boolean {
+  if (node.type === 'Literal' && node.value === null) {
+    return true;
+  }
+  return node.type === 'Identifier' && node.name === 'undefined';
+}
+
+function isSafeArgument(arg: Expression | SpreadElement): boolean {
+  if (arg.type === 'SpreadElement') {
+    return arg.argument.type === 'Identifier';
+  }
+
+  switch (arg.type) {
+    case 'Identifier':
+    case 'Literal':
+    case 'TemplateLiteral':
+      return true;
+
+    case 'MemberExpression':
+      if (
+        arg.object.type === 'Super' ||
+        arg.property.type === 'PrivateIdentifier'
+      ) {
+        return false;
+      }
+      if (!isSafeArgument(arg.object)) {
+        return false;
+      }
+      if (arg.computed) {
+        return isSafeArgument(arg.property);
+      }
+      return true;
+
+    case 'ArrayExpression':
+      return arg.elements.every((el) => el === null || isSafeArgument(el));
+
+    case 'ObjectExpression':
+      return arg.properties.every((prop) => {
+        if (prop.type === 'SpreadElement') {
+          return isSafeArgument(prop.argument);
+        }
+        const valueType = prop.value.type;
+        if (
+          valueType === 'ObjectPattern' ||
+          valueType === 'ArrayPattern' ||
+          valueType === 'RestElement' ||
+          valueType === 'AssignmentPattern'
+        ) {
+          return false;
+        }
+        return isSafeArgument(prop.value);
+      });
+
+    case 'UnaryExpression':
+    case 'UpdateExpression':
+      return isSafeArgument(arg.argument);
+
+    case 'BinaryExpression':
+    case 'LogicalExpression':
+      return (
+        arg.left.type !== 'PrivateIdentifier' &&
+        isSafeArgument(arg.left) &&
+        isSafeArgument(arg.right)
+      );
+
+    case 'ConditionalExpression':
+      return (
+        isSafeArgument(arg.test) &&
+        isSafeArgument(arg.consequent) &&
+        isSafeArgument(arg.alternate)
+      );
+
+    // CallExpression, NewExpression, etc.
+    default:
+      return false;
+  }
+}
+
+export const preferTimerArgs: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer passing function and arguments directly to setTimeout/setInterval instead of wrapping in an arrow function or using bind',
+      recommended: true
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      preferArgs:
+        'Pass function and arguments directly to timer function to avoid allocating an extra function'
+    }
+  },
+  create(context) {
+    const sourceCode = context.sourceCode;
+
+    return {
+      CallExpression(node: CallExpression) {
+        // Check if this is setTimeout/setInterval (with optional window/globalThis prefix)
+        const isTimerFunction =
+          (node.callee.type === 'Identifier' &&
+            (node.callee.name === 'setTimeout' ||
+              node.callee.name === 'setInterval')) ||
+          (node.callee.type === 'MemberExpression' &&
+            node.callee.object.type === 'Identifier' &&
+            (node.callee.object.name === 'window' ||
+              node.callee.object.name === 'globalThis') &&
+            node.callee.property.type === 'Identifier' &&
+            (node.callee.property.name === 'setTimeout' ||
+              node.callee.property.name === 'setInterval'));
+
+        if (!isTimerFunction) {
+          return;
+        }
+
+        if (node.arguments.length < 2) {
+          return;
+        }
+
+        const firstArg = node.arguments[0];
+        if (!firstArg || firstArg.type === 'SpreadElement') {
+          return;
+        }
+
+        const delayText = sourceCode.getText(node.arguments[1]!);
+        const timerCall = sourceCode.getText(node.callee);
+
+        let replacement: string | null = null;
+
+        // simple arrow functions, e.g. () => fn(args)
+        if (firstArg.type === 'ArrowFunctionExpression') {
+          const arrowFn = firstArg as ArrowFunctionExpression;
+
+          // skip if it is a block body
+          if (arrowFn.body.type === 'BlockStatement') {
+            return;
+          }
+
+          // skip if it has parameters
+          if (arrowFn.params.length > 0) {
+            return;
+          }
+
+          if (arrowFn.body.type !== 'CallExpression') {
+            return;
+          }
+
+          const callExpression = arrowFn.body;
+          const callee = callExpression.callee;
+          const callArgs = callExpression.arguments;
+
+          if (!callArgs.every(isSafeArgument)) {
+            return;
+          }
+
+          const calleeText = sourceCode.getText(callee);
+
+          if (callArgs.length === 0) {
+            replacement = `${timerCall}(${calleeText}, ${delayText})`;
+          } else {
+            const argsTexts = callArgs.map((arg) => sourceCode.getText(arg));
+            replacement = `${timerCall}(${calleeText}, ${delayText}, ${argsTexts.join(', ')})`;
+          }
+        }
+        // fn.bind(null/undefined, args)
+        else if (firstArg.type === 'CallExpression') {
+          const bindCall = firstArg;
+
+          if (
+            bindCall.callee.type !== 'MemberExpression' ||
+            bindCall.callee.property.type !== 'Identifier' ||
+            bindCall.callee.property.name !== 'bind' ||
+            bindCall.arguments.length === 0
+          ) {
+            return;
+          }
+
+          const bindContext = bindCall.arguments[0];
+          if (!bindContext || bindContext.type === 'SpreadElement') {
+            return;
+          }
+
+          if (!isNullOrUndefined(bindContext)) {
+            return;
+          }
+
+          const fnText = sourceCode.getText(bindCall.callee.object);
+          const bindArgs = bindCall.arguments.slice(1);
+
+          // Check if any bind argument contains a call expression or other unsafe construct
+          if (!bindArgs.every(isSafeArgument)) {
+            return;
+          }
+
+          if (bindArgs.length === 0) {
+            replacement = `${timerCall}(${fnText}, ${delayText})`;
+          } else {
+            const argsTexts = bindArgs.map((arg) => sourceCode.getText(arg));
+            replacement = `${timerCall}(${fnText}, ${delayText}, ${argsTexts.join(', ')})`;
+          }
+        } else {
+          return;
+        }
+
+        if (replacement) {
+          context.report({
+            node,
+            messageId: 'preferArgs',
+            fix(fixer) {
+              return fixer.replaceText(node, replacement);
+            }
+          });
+        }
+      }
+    };
+  }
+};


### PR DESCRIPTION
Prefers `setTimeout(fn, timeMs, arg1, arg2)` instead of `setTimeout(()
=> fn(arg1, arg2), timeMs)`.
