### PR TITLE
feat: add `prefer-array-from-map` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ export default [
 | Rule | Description | Recommended | Fixable | Requires Types |
 |------|-------------|-------------|---------|----------------|
 | [no-indexof-equality](./src/rules/no-indexof-equality.ts) | Prefer `startsWith()` for strings and direct array access over `indexOf()` equality checks | ✖️ | ✅ | ✅ |
+| [prefer-array-from-map](./src/rules/prefer-array-from-map.ts) | Prefer `Array.from(iterable, mapper)` over `[...iterable].map(mapper)` to avoid intermediate array allocation | ✅ | ✅ | ✖️ |
 | [prefer-timer-args](./src/rules/prefer-timer-args.ts) | Prefer passing function and arguments directly to `setTimeout`/`setInterval` instead of wrapping in an arrow function or using `bind` | ✅ | ✅ | ✖️ |
 
 ## License

--- a/src/configs/performance-improvements.ts
+++ b/src/configs/performance-improvements.ts
@@ -7,6 +7,7 @@ export const performanceImprovements = (
     e18e: plugin
   },
   rules: {
+    'e18e/prefer-array-from-map': 'error',
     'e18e/prefer-timer-args': 'error'
   }
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import {moduleReplacements} from './configs/module-replacements.js';
 import {performanceImprovements} from './configs/performance-improvements.js';
 import {preferArrayAt} from './rules/prefer-array-at.js';
 import {preferArrayFill} from './rules/prefer-array-fill.js';
+import {preferArrayFromMap} from './rules/prefer-array-from-map.js';
 import {preferIncludes} from './rules/prefer-includes.js';
 import {preferArrayToReversed} from './rules/prefer-array-to-reversed.js';
 import {preferArrayToSorted} from './rules/prefer-array-to-sorted.js';
@@ -27,6 +28,7 @@ const plugin: ESLint.Plugin = {
   rules: {
     'prefer-array-at': preferArrayAt,
     'prefer-array-fill': preferArrayFill,
+    'prefer-array-from-map': preferArrayFromMap,
     'prefer-includes': preferIncludes,
     'prefer-array-to-reversed': preferArrayToReversed,
     'prefer-array-to-sorted': preferArrayToSorted,

--- a/src/rules/prefer-array-from-map.test.ts
+++ b/src/rules/prefer-array-from-map.test.ts
@@ -1,0 +1,168 @@
+import {RuleTester} from 'eslint';
+import {preferArrayFromMap} from './prefer-array-from-map.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('prefer-array-from-map', preferArrayFromMap, {
+  valid: [
+    // Already using Array.from with mapper
+    'const result = Array.from(iterable, x => x * 2)',
+    'const result = Array.from(arr, mapper)',
+
+    // Spread without .map()
+    'const arr = [...iterable]',
+
+    // .map() on a regular array (not from spread)
+    'const result = arr.map(x => x * 2)',
+    'const result = [1, 2, 3].map(x => x * 2)',
+
+    // Array with multiple elements (not just a single spread)
+    'const result = [...arr1, ...arr2].map(x => x * 2)',
+    'const result = [1, ...arr].map(x => x * 2)',
+    'const result = [...arr, 2].map(x => x * 2)',
+
+    // .map() with multiple arguments (thisArg)
+    'const result = [...arr].map(fn, thisArg)',
+
+    // No spread in array literal
+    'const result = [arr].map(x => x * 2)',
+
+    // Empty array
+    'const result = [].map(x => x * 2)'
+  ],
+
+  invalid: [
+    // Basic case with arrow function
+    {
+      code: 'const result = [...arr].map(x => x * 2)',
+      output: 'const result = Array.from(arr, x => x * 2)',
+      errors: [
+        {
+          messageId: 'preferArrayFrom',
+          data: {iterable: 'arr', mapper: 'x => x * 2'}
+        }
+      ]
+    },
+
+    // With named function
+    {
+      code: 'const result = [...items].map(double)',
+      output: 'const result = Array.from(items, double)',
+      errors: [
+        {
+          messageId: 'preferArrayFrom',
+          data: {iterable: 'items', mapper: 'double'}
+        }
+      ]
+    },
+
+    // With function expression
+    {
+      code: 'const result = [...list].map(function(x) { return x * 2 })',
+      output: 'const result = Array.from(list, function(x) { return x * 2 })',
+      errors: [
+        {
+          messageId: 'preferArrayFrom',
+          data: {iterable: 'list', mapper: 'function(x) { return x * 2 }'}
+        }
+      ]
+    },
+
+    // With method call on iterable
+    {
+      code: 'const result = [...map.values()].map(process)',
+      output: 'const result = Array.from(map.values(), process)',
+      errors: [
+        {
+          messageId: 'preferArrayFrom',
+          data: {iterable: 'map.values()', mapper: 'process'}
+        }
+      ]
+    },
+
+    // Multiple occurrences
+    {
+      code: `const a = [...arr1].map(x => x * 2)
+const b = [...arr2].map(y => y + 1)`,
+      output: `const a = Array.from(arr1, x => x * 2)
+const b = Array.from(arr2, y => y + 1)`,
+      errors: [
+        {
+          messageId: 'preferArrayFrom',
+          data: {iterable: 'arr1', mapper: 'x => x * 2'}
+        },
+        {
+          messageId: 'preferArrayFrom',
+          data: {iterable: 'arr2', mapper: 'y => y + 1'}
+        }
+      ]
+    },
+
+    // Used in return statement
+    {
+      code: 'function transform(items) { return [...items].map(x => x * 2) }',
+      output:
+        'function transform(items) { return Array.from(items, x => x * 2) }',
+      errors: [
+        {
+          messageId: 'preferArrayFrom',
+          data: {iterable: 'items', mapper: 'x => x * 2'}
+        }
+      ]
+    },
+
+    // Used in expression
+    {
+      code: 'console.log([...data].map(format))',
+      output: 'console.log(Array.from(data, format))',
+      errors: [
+        {
+          messageId: 'preferArrayFrom',
+          data: {iterable: 'data', mapper: 'format'}
+        }
+      ]
+    },
+
+    // Complex iterable expression
+    {
+      code: 'const result = [...getItems()].map(x => x.id)',
+      output: 'const result = Array.from(getItems(), x => x.id)',
+      errors: [
+        {
+          messageId: 'preferArrayFrom',
+          data: {iterable: 'getItems()', mapper: 'x => x.id'}
+        }
+      ]
+    },
+
+    // With member expression
+    {
+      code: 'const result = [...this.items].map(process)',
+      output: 'const result = Array.from(this.items, process)',
+      errors: [
+        {
+          messageId: 'preferArrayFrom',
+          data: {iterable: 'this.items', mapper: 'process'}
+        }
+      ]
+    },
+
+    // Chained with other array methods
+    {
+      code: 'const doubled = [...numbers].map(n => n * 2).filter(n => n > 10)',
+      output:
+        'const doubled = Array.from(numbers, n => n * 2).filter(n => n > 10)',
+      errors: [
+        {
+          messageId: 'preferArrayFrom',
+          data: {iterable: 'numbers', mapper: 'n => n * 2'}
+        }
+      ]
+    }
+  ]
+});

--- a/src/rules/prefer-array-from-map.ts
+++ b/src/rules/prefer-array-from-map.ts
@@ -1,0 +1,77 @@
+import type {Rule} from 'eslint';
+import type {CallExpression} from 'estree';
+
+export const preferArrayFromMap: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer Array.from(iterable, mapper) over [...iterable].map(mapper) to avoid intermediate array allocation',
+      recommended: true
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      preferArrayFrom:
+        'Use Array.from({{iterable}}, {{mapper}}) instead of [...{{iterable}}].map({{mapper}}) to avoid creating an intermediate array'
+    }
+  },
+  create(context) {
+    const sourceCode = context.sourceCode;
+
+    return {
+      CallExpression(node: CallExpression) {
+        // Check if this is a .map() call
+        if (node.callee.type !== 'MemberExpression') {
+          return;
+        }
+
+        if (
+          node.callee.property.type !== 'Identifier' ||
+          node.callee.property.name !== 'map'
+        ) {
+          return;
+        }
+
+        // Check if .map() is being called on an array literal with spread
+        if (node.callee.object.type !== 'ArrayExpression') {
+          return;
+        }
+
+        const arrayExpr = node.callee.object;
+
+        // Check if the array has exactly one element and it's a spread element
+        if (
+          arrayExpr.elements.length !== 1 ||
+          arrayExpr.elements[0]?.type !== 'SpreadElement'
+        ) {
+          return;
+        }
+
+        // Check if map has exactly one argument (the mapper function)
+        if (node.arguments.length !== 1) {
+          return;
+        }
+
+        const spreadElement = arrayExpr.elements[0];
+        const iterableText = sourceCode.getText(spreadElement.argument);
+        const mapperText = sourceCode.getText(node.arguments[0]!);
+
+        context.report({
+          node,
+          messageId: 'preferArrayFrom',
+          data: {
+            iterable: iterableText,
+            mapper: mapperText
+          },
+          fix(fixer) {
+            return fixer.replaceText(
+              node,
+              `Array.from(${iterableText}, ${mapperText})`
+            );
+          }
+        });
+      }
+    };
+  }
+};


### PR DESCRIPTION
Prefers `Array.from(iter, mapper)` over `[...iter].map(mapper)`.
