### PR TITLE
fix: skip assignments in `prefer-array-at`

### DIFF
--- a/src/rules/prefer-array-at.test.ts
+++ b/src/rules/prefer-array-at.test.ts
@@ -37,7 +37,11 @@ ruleTester.run('prefer-array-at', preferArrayAt, {
 
     // Edge cases
     'const empty = []',
-    'const literal = [1, 2, 3][0]'
+    'const literal = [1, 2, 3][0]',
+
+    // Assignments
+    'arr[arr.length - 1] = value',
+    'myArray[myArray.length - 1] = 42'
   ],
 
   invalid: [

--- a/src/rules/prefer-array-at.ts
+++ b/src/rules/prefer-array-at.ts
@@ -18,7 +18,7 @@ export const preferArrayAt: Rule.RuleModule = {
     const sourceCode = context.sourceCode;
 
     return {
-      MemberExpression(node: MemberExpression) {
+      MemberExpression(node: MemberExpression & Rule.NodeParentExtension) {
         if (!node.computed || !node.property) {
           return;
         }
@@ -57,6 +57,15 @@ export const preferArrayAt: Rule.RuleModule = {
         const lengthArrayText = sourceCode.getText(leftMember.object);
 
         if (arrayText !== lengthArrayText) {
+          return;
+        }
+
+        const parent = node.parent;
+        if (
+          parent &&
+          parent.type === 'AssignmentExpression' &&
+          parent.left === node
+        ) {
           return;
         }
 


### PR DESCRIPTION
We could end up with invalid code from:

```ts
arr[arr.length - 1] = arr[arr.length - 1] + 2;
```

Fixes #27