### PR TITLE
fix: exclude objects/spread from `prefer-spread-syntax`

### DIFF
--- a/src/rules/prefer-spread-syntax.test.ts
+++ b/src/rules/prefer-spread-syntax.test.ts
@@ -21,6 +21,11 @@ ruleTester.run('prefer-spread-syntax', preferSpreadSyntax, {
     'Array.from(iterable, x => x * 2);',
     'Array.from(arr, mapper);',
 
+    // Array.from with object literal or spread
+    'Array.from({length: 5});',
+    'Array.from({length: N}).fill(0);',
+    'Array.from(...args).fill(0)',
+
     // Already using spread
     'const arr = [...iterable];',
 

--- a/src/rules/prefer-spread-syntax.ts
+++ b/src/rules/prefer-spread-syntax.ts
@@ -63,9 +63,15 @@ export const preferSpreadSyntax: Rule.RuleModule = {
           node.callee.property.name === 'from' &&
           node.arguments.length === 1
         ) {
-          const iterableText = sourceCode.getText(node.arguments[0]!);
-          replacement = `[...${iterableText}]`;
-          messageId = 'preferSpreadArrayFrom';
+          const firstArg = node.arguments[0]!;
+          if (
+            firstArg.type !== 'SpreadElement' &&
+            firstArg.type !== 'ObjectExpression'
+          ) {
+            const iterableText = sourceCode.getText(firstArg);
+            replacement = `[...${iterableText}]`;
+            messageId = 'preferSpreadArrayFrom';
+          }
         }
         // Object.assign({...}, ...)
         else if (


### PR DESCRIPTION
Excludes `Array.from(...args)` and `Array.from({ anything })` since we
can't iterate objects.

Fixes #30.
