### PR TITLE
feat: add `prefer-regex-test` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ Copying these rules into your `rules` object will achieve the same effect as usi
 | [prefer-array-from-map](./src/rules/prefer-array-from-map.ts) | Prefer `Array.from(iterable, mapper)` over `[...iterable].map(mapper)` to avoid intermediate array allocation | ✅ | ✅ | ✖️ |
 | [prefer-timer-args](./src/rules/prefer-timer-args.ts) | Prefer passing function and arguments directly to `setTimeout`/`setInterval` instead of wrapping in an arrow function or using `bind` | ✅ | ✅ | ✖️ |
 | [prefer-date-now](./src/rules/prefer-date-now.ts) | Prefer `Date.now()` over `new Date().getTime()` and `+new Date()` | ✅ | ✅ | ✖️ |
+| [prefer-regex-test](./src/rules/prefer-regex-test.ts) | Prefer `RegExp.test()` over `String.match()` and `RegExp.exec()` when only checking for match existence | ✅ | ✅ | 🔶 |
+
+**Legend for "Requires Types" column:**
+- ✖️ = Does not require types
+- ✅ = Requires types
+- 🔶 = Optionally uses types (works without TypeScript but more powerful with it)
 
 ## License
 

--- a/src/configs/performance-improvements.ts
+++ b/src/configs/performance-improvements.ts
@@ -9,6 +9,7 @@ export const performanceImprovements = (
   rules: {
     'e18e/prefer-array-from-map': 'error',
     'e18e/prefer-timer-args': 'error',
-    'e18e/prefer-date-now': 'error'
+    'e18e/prefer-date-now': 'error',
+    'e18e/prefer-regex-test': 'error'
   }
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import {preferUrlCanParse} from './rules/prefer-url-canparse.js';
 import {noIndexOfEquality} from './rules/no-indexof-equality.js';
 import {preferTimerArgs} from './rules/prefer-timer-args.js';
 import {preferDateNow} from './rules/prefer-date-now.js';
+import {preferRegexTest} from './rules/prefer-regex-test.js';
 import {rules as dependRules} from 'eslint-plugin-depend';
 
 const plugin: ESLint.Plugin = {
@@ -42,6 +43,7 @@ const plugin: ESLint.Plugin = {
     'no-indexof-equality': noIndexOfEquality as never as Rule.RuleModule,
     'prefer-timer-args': preferTimerArgs,
     'prefer-date-now': preferDateNow,
+    'prefer-regex-test': preferRegexTest as never as Rule.RuleModule,
     ...dependRules
   }
 };

--- a/src/rules/prefer-regex-test.test.ts
+++ b/src/rules/prefer-regex-test.test.ts
@@ -1,0 +1,550 @@
+import {RuleTester} from 'eslint';
+import {RuleTester as TSRuleTester} from '@typescript-eslint/rule-tester';
+import {preferRegexTest} from './prefer-regex-test.js';
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const rootDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..'
+);
+const typedRuleTester = new TSRuleTester({
+  languageOptions: {
+    parserOptions: {
+      projectService: {
+        allowDefaultProject: ['*.ts'],
+        defaultProject: './tsconfig.json'
+      },
+      tsconfigRootDir: rootDir
+    }
+  }
+});
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('prefer-regex-test (untyped)', preferRegexTest as never, {
+  valid: [
+    // not used in a conditional
+    'const result = str.match(/test/);',
+    'const result = /test/.exec(str);',
+    'const matches = str.match(/test/g);',
+
+    // .test() already used
+    'if (/test/.test(str)) {}',
+    'if (regex.test(str)) {}',
+
+    // can't resolve to regex
+    'if (str.match(pattern)) {}',
+    'if (pattern.exec(str)) {}',
+
+    // no arguments
+    'if (str.match()) {}',
+
+    // multiple arguments
+    "if (str.match(/test/, 'extra')) {}",
+
+    // unrelated method calls
+    "if (str.includes('test')) {}",
+    "if (str.indexOf('test')) {}"
+  ],
+
+  invalid: [
+    {
+      code: 'if (str.match(/test/)) {}',
+      output: 'if (/test/.test(str)) {}',
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 22
+        }
+      ]
+    },
+    {
+      code: 'if (/test/.exec(str)) {}',
+      output: 'if (/test/.test(str)) {}',
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 21
+        }
+      ]
+    },
+
+    // with flags
+    {
+      code: 'if (str.match(/test/i)) {}',
+      output: 'if (/test/i.test(str)) {}',
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 23
+        }
+      ]
+    },
+
+    // while statement
+    {
+      code: 'while (str.match(/test/)) {}',
+      output: 'while (/test/.test(str)) {}',
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 8,
+          endLine: 1,
+          endColumn: 25
+        }
+      ]
+    },
+
+    // for statement
+    {
+      code: 'for (; str.match(/test/);) {}',
+      output: 'for (; /test/.test(str);) {}',
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 8,
+          endLine: 1,
+          endColumn: 25
+        }
+      ]
+    },
+
+    // do...while statement
+    {
+      code: 'do {} while (str.match(/test/));',
+      output: 'do {} while (/test/.test(str));',
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    },
+
+    // using a const regex variable
+    {
+      code: 'const regex = /test/; if (str.match(regex)) {}',
+      output: 'const regex = /test/; if (regex.test(str)) {}',
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 27,
+          endLine: 1,
+          endColumn: 43
+        }
+      ]
+    },
+
+    // using a let regex variable
+    {
+      code: 'let regex = /test/; if (str.match(regex)) {}',
+      output: 'let regex = /test/; if (regex.test(str)) {}',
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 25,
+          endLine: 1,
+          endColumn: 41
+        }
+      ]
+    },
+
+    // using a var regex variable
+    {
+      code: 'var regex = /test/; if (str.match(regex)) {}',
+      output: 'var regex = /test/; if (regex.test(str)) {}',
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 25,
+          endLine: 1,
+          endColumn: 41
+        }
+      ]
+    },
+
+    // using a const regex variable with exec
+    {
+      code: 'const regex = /test/; if (regex.exec(str)) {}',
+      output: 'const regex = /test/; if (regex.test(str)) {}',
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 27,
+          endLine: 1,
+          endColumn: 42
+        }
+      ]
+    },
+
+    // member expression as string
+    {
+      code: 'if (obj.prop.match(/test/)) {}',
+      output: 'if (/test/.test(obj.prop)) {}',
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 27
+        }
+      ]
+    },
+
+    // member expression as regex
+    {
+      code: 'if (/test/.exec(obj.prop)) {}',
+      output: 'if (/test/.test(obj.prop)) {}',
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 26
+        }
+      ]
+    },
+
+    // multiple patterns
+    {
+      code: 'if (str.match(/a/)) {}\nif (/b/.exec(str)) {}',
+      output: 'if (/a/.test(str)) {}\nif (/b/.test(str)) {}',
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 19
+        },
+        {
+          messageId: 'preferTest',
+          line: 2,
+          column: 5,
+          endLine: 2,
+          endColumn: 18
+        }
+      ]
+    },
+
+    // new RegExp()
+    {
+      code: "const regex = new RegExp('test'); if (str.match(regex)) {}",
+      output: "const regex = new RegExp('test'); if (regex.test(str)) {}",
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 39,
+          endLine: 1,
+          endColumn: 55
+        }
+      ]
+    },
+
+    // new RegExp() with exec
+    {
+      code: "const regex = new RegExp('test'); if (regex.exec(str)) {}",
+      output: "const regex = new RegExp('test'); if (regex.test(str)) {}",
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 39,
+          endLine: 1,
+          endColumn: 54
+        }
+      ]
+    },
+
+    // new window.RegExp()
+    {
+      code: "const regex = new window.RegExp('test'); if (str.match(regex)) {}",
+      output:
+        "const regex = new window.RegExp('test'); if (regex.test(str)) {}",
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 46,
+          endLine: 1,
+          endColumn: 62
+        }
+      ]
+    },
+
+    // new globalThis.RegExp()
+    {
+      code: "const regex = new globalThis.RegExp('test'); if (str.match(regex)) {}",
+      output:
+        "const regex = new globalThis.RegExp('test'); if (regex.test(str)) {}",
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 50,
+          endLine: 1,
+          endColumn: 66
+        }
+      ]
+    },
+
+    // negation
+    {
+      code: 'if (!str.match(/test/)) {}',
+      output: 'if (!/test/.test(str)) {}',
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 6,
+          endLine: 1,
+          endColumn: 23
+        }
+      ]
+    },
+
+    // ternaries
+    {
+      code: 'const x = str.match(/test/) ? a : b;',
+      output: 'const x = /test/.test(str) ? a : b;',
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 28
+        }
+      ]
+    },
+
+    // inside an AND expression (left side)
+    {
+      code: 'if (str.match(/test/) && other) {}',
+      output: 'if (/test/.test(str) && other) {}',
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 22
+        }
+      ]
+    },
+
+    // inside an AND expression (right side)
+    {
+      code: 'if (other && str.match(/test/)) {}',
+      output: 'if (other && /test/.test(str)) {}',
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    },
+
+    // inside an OR expression (left side)
+    {
+      code: 'if (str.match(/test/) || fallback) {}',
+      output: 'if (/test/.test(str) || fallback) {}',
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 22
+        }
+      ]
+    },
+
+    // inside an OR expression (right side)
+    {
+      code: 'if (fallback || str.match(/test/)) {}',
+      output: 'if (fallback || /test/.test(str)) {}',
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 17,
+          endLine: 1,
+          endColumn: 34
+        }
+      ]
+    },
+
+    // negation in AND expression
+    {
+      code: 'if (a && !str.match(/test/)) {}',
+      output: 'if (a && !/test/.test(str)) {}',
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 28
+        }
+      ]
+    },
+
+    // double negation
+    {
+      code: 'if (!!str.match(/test/)) {}',
+      output: 'if (!!/test/.test(str)) {}',
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 1,
+          column: 7,
+          endLine: 1,
+          endColumn: 24
+        }
+      ]
+    }
+  ]
+});
+
+typedRuleTester.run('prefer-regex-test (typed)', preferRegexTest, {
+  valid: [
+    // Non-regex types should not be caught
+    {
+      code: `
+        function test(pattern: string) {
+          if (str.match(pattern)) {}
+        }
+      `
+    }
+  ],
+
+  invalid: [
+    // typed function parameter
+    {
+      code: `
+        function test(regex: RegExp, str: string) {
+          if (str.match(regex)) {}
+        }
+      `,
+      output: `
+        function test(regex: RegExp, str: string) {
+          if (regex.test(str)) {}
+        }
+      `,
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 3,
+          column: 15,
+          endLine: 3,
+          endColumn: 31
+        }
+      ]
+    },
+
+    // typed function return value
+    {
+      code: `
+        function getRegex(): RegExp {
+          return /test/;
+        }
+        if (str.match(getRegex())) {}
+      `,
+      output: `
+        function getRegex(): RegExp {
+          return /test/;
+        }
+        if (getRegex().test(str)) {}
+      `,
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 5,
+          column: 13,
+          endLine: 5,
+          endColumn: 34
+        }
+      ]
+    },
+
+    // basic typed variable
+    {
+      code: `
+        const regex: RegExp = getFromSomewhere();
+        if (str.match(regex)) {}
+      `,
+      output: `
+        const regex: RegExp = getFromSomewhere();
+        if (regex.test(str)) {}
+      `,
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 3,
+          column: 13,
+          endLine: 3,
+          endColumn: 29
+        }
+      ]
+    },
+
+    // RegExp from object property
+    {
+      code: `
+        interface Config {
+          pattern: RegExp;
+        }
+        function test(config: Config) {
+          if (str.match(config.pattern)) {}
+        }
+      `,
+      output: `
+        interface Config {
+          pattern: RegExp;
+        }
+        function test(config: Config) {
+          if (config.pattern.test(str)) {}
+        }
+      `,
+      errors: [
+        {
+          messageId: 'preferTest',
+          line: 6,
+          column: 15,
+          endLine: 6,
+          endColumn: 40
+        }
+      ]
+    }
+  ]
+});

--- a/src/rules/prefer-regex-test.ts
+++ b/src/rules/prefer-regex-test.ts
@@ -1,0 +1,229 @@
+import type {TSESLint, TSESTree} from '@typescript-eslint/utils';
+import {tryGetTypedParserServices} from '../utils/typescript.js';
+
+type MessageIds = 'preferTest';
+
+function isRegExpLiteral(node: TSESTree.Node): node is TSESTree.Literal {
+  return (
+    node.type === 'Literal' &&
+    'regex' in node &&
+    node.regex !== undefined &&
+    node.regex !== null
+  );
+}
+
+/**
+ * Checks if a node is a `new RegExp(...)`
+ */
+function isRegExpConstructor(node: TSESTree.Node): boolean {
+  if (node.type !== 'NewExpression') {
+    return false;
+  }
+
+  const {callee} = node;
+
+  // new RegExp()
+  if (callee.type === 'Identifier' && callee.name === 'RegExp') {
+    return true;
+  }
+
+  // new window.RegExp() or new globalThis.RegExp()
+  if (
+    callee.type === 'MemberExpression' &&
+    callee.object.type === 'Identifier' &&
+    (callee.object.name === 'window' || callee.object.name === 'globalThis') &&
+    callee.property.type === 'Identifier' &&
+    callee.property.name === 'RegExp' &&
+    !callee.computed
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Checks if a node is a RegExp (literal or constructor)
+ */
+function isRegExp(node: TSESTree.Node | null | undefined): boolean {
+  return (
+    node !== null &&
+    node !== undefined &&
+    (isRegExpLiteral(node) || isRegExpConstructor(node))
+  );
+}
+
+/**
+ * Checks if a node resolves to a RegExp using TypeScript types (when available)
+ */
+function isRegExpByType(
+  node: TSESTree.Node,
+  context: TSESLint.RuleContext<MessageIds, []>
+): boolean {
+  const services = tryGetTypedParserServices(context);
+  if (!services) {
+    return false;
+  }
+
+  const type = services.getTypeAtLocation(node);
+  if (!type) {
+    return false;
+  }
+
+  const checker = services.program.getTypeChecker();
+  const typeString = checker.typeToString(type);
+
+  return typeString === 'RegExp';
+}
+
+/**
+ * Checks if a node resolves to a RegExp (literal, constructor, or by type)
+ */
+function resolvesToRegExp(
+  node: TSESTree.Node,
+  context: TSESLint.RuleContext<MessageIds, []>
+): boolean {
+  if (isRegExpByType(node, context)) {
+    return true;
+  }
+
+  if (isRegExp(node)) {
+    return true;
+  }
+
+  if (node.type !== 'Identifier') {
+    return false;
+  }
+
+  const scope = context.sourceCode.getScope(node);
+  const variable = scope.references.find(
+    (ref) => ref.identifier === node
+  )?.resolved;
+
+  if (!variable) {
+    return false;
+  }
+
+  for (const def of variable.defs) {
+    if (def.type === 'Variable' && def.node.type === 'VariableDeclarator') {
+      const init = def.node.init;
+      if (isRegExp(init)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Checks if a node is in a test/condition
+ */
+function isInBooleanContext(node: TSESTree.Node): boolean {
+  const parent = node.parent;
+
+  if (!parent) {
+    return false;
+  }
+
+  // if/while/for/do-while test
+  if (
+    (parent.type === 'IfStatement' && parent.test === node) ||
+    (parent.type === 'WhileStatement' && parent.test === node) ||
+    (parent.type === 'ForStatement' && parent.test === node) ||
+    (parent.type === 'DoWhileStatement' && parent.test === node)
+  ) {
+    return true;
+  }
+
+  // ternaries
+  if (parent.type === 'ConditionalExpression' && parent.test === node) {
+    return true;
+  }
+
+  // check the parent
+  if (
+    (parent.type === 'UnaryExpression' && parent.operator === '!') ||
+    (parent.type === 'LogicalExpression' &&
+      (parent.operator === '&&' || parent.operator === '||'))
+  ) {
+    return isInBooleanContext(parent);
+  }
+
+  return false;
+}
+
+export const preferRegexTest: TSESLint.RuleModule<MessageIds, []> = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'prefer `RegExp.test()` over `String.match()` and `RegExp.exec()` when only checking for match existence'
+    },
+    fixable: 'code',
+    messages: {
+      preferTest:
+        'Prefer `{{regex}}.test({{string}})` over `{{original}}` for boolean checks'
+    },
+    schema: []
+  },
+  defaultOptions: [],
+
+  create(context) {
+    return {
+      CallExpression(node: TSESTree.CallExpression) {
+        if (!isInBooleanContext(node)) {
+          return;
+        }
+
+        const {callee} = node;
+
+        if (callee.type !== 'MemberExpression') {
+          return;
+        }
+
+        const property = callee.property;
+
+        if (property.type !== 'Identifier' || node.arguments.length !== 1) {
+          return;
+        }
+
+        let regexNode: TSESTree.Node;
+        let stringNode: TSESTree.Node;
+
+        if (property.name === 'match') {
+          // str.match(regex)
+          stringNode = callee.object;
+          regexNode = node.arguments[0]!;
+        } else if (property.name === 'exec') {
+          // regex.exec(str)
+          regexNode = callee.object;
+          stringNode = node.arguments[0]!;
+        } else {
+          return;
+        }
+
+        if (!resolvesToRegExp(regexNode, context)) {
+          return;
+        }
+
+        const sourceCode = context.sourceCode;
+        const regexText = sourceCode.getText(regexNode);
+        const stringText = sourceCode.getText(stringNode);
+
+        context.report({
+          node,
+          messageId: 'preferTest',
+          data: {
+            regex: regexText,
+            string: stringText,
+            original: sourceCode.getText(node)
+          },
+          fix(fixer) {
+            return fixer.replaceText(node, `${regexText}.test(${stringText})`);
+          }
+        });
+      }
+    };
+  }
+};

--- a/src/utils/typescript.ts
+++ b/src/utils/typescript.ts
@@ -18,14 +18,25 @@ export interface ParserServices {
   program: ts.Program;
 }
 
+export function tryGetTypedParserServices(
+  context: Readonly<TSESLint.RuleContext<string, unknown[]>>
+): ParserServicesWithTypeInformation | null {
+  if (context.sourceCode.parserServices?.program == null) {
+    return null;
+  }
+
+  return context.sourceCode.parserServices as ParserServicesWithTypeInformation;
+}
+
 export function getTypedParserServices(
   context: Readonly<TSESLint.RuleContext<string, unknown[]>>
 ): ParserServicesWithTypeInformation {
-  if (context.sourceCode.parserServices?.program == null) {
+  const services = tryGetTypedParserServices(context);
+  if (services === null) {
     throw new Error(
       `You have used a rule which requires type information. Please ensure you have typescript-eslint setup alongside this plugin and configured to enable type-aware linting. See https://typescript-eslint.io/getting-started/typed-linting for more information.`
     );
   }
 
-  return context.sourceCode.parserServices as ParserServicesWithTypeInformation;
+  return services;
 }


### PR DESCRIPTION
Prefers `regex.test(str)` over `str.match(regex)` in boolean situations.
