### PR TITLE
fix(prefer-spread-syntax): exclude `Buffer.concat`

### DIFF
--- a/src/rules/prefer-spread-syntax.test.ts
+++ b/src/rules/prefer-spread-syntax.test.ts
@@ -17,6 +17,10 @@ ruleTester.run('prefer-spread-syntax', preferSpreadSyntax, {
     // concat with no arguments
     'arr.concat();',
 
+    // Buffer.concat is not replaceable with spread
+    'Buffer.concat([buf1, buf2]);',
+    'Buffer.concat(buffers);',
+
     // Array.from with mapper function (should keep as-is)
     'Array.from(iterable, x => x * 2);',
     'Array.from(arr, mapper);',

--- a/src/rules/prefer-spread-syntax.ts
+++ b/src/rules/prefer-spread-syntax.ts
@@ -42,10 +42,15 @@ export const preferSpreadSyntax: Rule.RuleModule = {
         let replacement: string | undefined;
 
         // array.concat()
+        // excluding Buffer.concat()
         if (
           node.callee.property.type === 'Identifier' &&
           node.callee.property.name === 'concat' &&
-          node.arguments.length > 0
+          node.arguments.length > 0 &&
+          !(
+            node.callee.object.type === 'Identifier' &&
+            node.callee.object.name === 'Buffer'
+          )
         ) {
           const arrayText = sourceCode.getText(node.callee.object);
           const argTexts = node.arguments.map((arg) => sourceCode.getText(arg));


### PR DESCRIPTION
It is invalid to replace `Buffer.concat(buf)` with `[...Buffer,
...buf]`, so we exclude it as a special case.

Fixes #47.
