### PR TITLE
fix(prefer-array-at): make the rule type-enhanced

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Read more at the
 
 | Rule | Description | Recommended | Fixable | Requires Types |
 |------|-------------|-------------|---------|----------------|
-| [prefer-array-at](./src/rules/prefer-array-at.ts) | Prefer `Array.prototype.at()` over length-based indexing | ✅ | ✅ | ✖️ |
+| [prefer-array-at](./src/rules/prefer-array-at.ts) | Prefer `Array.prototype.at()` over length-based indexing | ✅ | ✅ | 🔶 |
 | [prefer-array-fill](./src/rules/prefer-array-fill.ts) | Prefer `Array.prototype.fill()` over `Array.from()` or `map()` with constant values | ✅ | ✅ | ✖️ |
 | [prefer-includes](./src/rules/prefer-includes.ts) | Prefer `.includes()` over `indexOf()` comparisons for arrays and strings | ✅ | ✅ | ✖️ |
 | [prefer-array-to-reversed](./src/rules/prefer-array-to-reversed.ts) | Prefer `Array.prototype.toReversed()` over copying and reversing arrays | ✅ | ✅ | ✖️ |

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ const plugin: ESLint.Plugin = {
   },
   configs: {},
   rules: {
-    'prefer-array-at': preferArrayAt,
+    'prefer-array-at': preferArrayAt as never as Rule.RuleModule,
     'prefer-array-fill': preferArrayFill,
     'prefer-array-from-map': preferArrayFromMap,
     'prefer-includes': preferIncludes,

--- a/src/rules/prefer-array-at.ts
+++ b/src/rules/prefer-array-at.ts
@@ -1,12 +1,13 @@
-import type {Rule} from 'eslint';
-import type {MemberExpression} from 'estree';
+import type {TSESLint, TSESTree} from '@typescript-eslint/utils';
+import {isArrayType, isStringType} from '../utils/typescript.js';
 
-export const preferArrayAt: Rule.RuleModule = {
+type MessageIds = 'preferAt';
+
+export const preferArrayAt: TSESLint.RuleModule<MessageIds, []> = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Prefer Array.prototype.at() over length-based indexing',
-      recommended: true
+      description: 'Prefer Array.prototype.at() over length-based indexing'
     },
     fixable: 'code',
     schema: [],
@@ -14,11 +15,12 @@ export const preferArrayAt: Rule.RuleModule = {
       preferAt: 'Use .at(-1) instead of [{{array}}.length - 1]'
     }
   },
+  defaultOptions: [],
   create(context) {
     const sourceCode = context.sourceCode;
 
     return {
-      MemberExpression(node: MemberExpression & Rule.NodeParentExtension) {
+      MemberExpression(node: TSESTree.MemberExpression) {
         if (!node.computed || !node.property) {
           return;
         }
@@ -65,6 +67,14 @@ export const preferArrayAt: Rule.RuleModule = {
           parent &&
           parent.type === 'AssignmentExpression' &&
           parent.left === node
+        ) {
+          return;
+        }
+
+        // Check if the object supports .at() (array or string, when types are available)
+        if (
+          !isArrayType(node.object, context) &&
+          !isStringType(node.object, context)
         ) {
           return;
         }

--- a/src/utils/typescript.ts
+++ b/src/utils/typescript.ts
@@ -40,3 +40,77 @@ export function getTypedParserServices(
 
   return services;
 }
+
+const typedArrayTypes = [
+  'Int8Array',
+  'Uint8Array',
+  'Uint8ClampedArray',
+  'Int16Array',
+  'Uint16Array',
+  'Int32Array',
+  'Uint32Array',
+  'Float32Array',
+  'Float64Array',
+  'BigInt64Array',
+  'BigUint64Array'
+];
+
+/**
+ * Checks if a node's type is an Array type (Array, tuple, or typed array)
+ * Returns true if types are unavailable (to avoid false negatives)
+ */
+export function isArrayType(
+  node: TSESTree.Node,
+  context: Readonly<TSESLint.RuleContext<string, unknown[]>>
+): boolean {
+  const services = tryGetTypedParserServices(context);
+  if (!services) {
+    return true;
+  }
+
+  const type = services.getTypeAtLocation(node);
+  if (!type) {
+    return true;
+  }
+
+  const checker = services.program.getTypeChecker();
+
+  if (checker.isArrayType(type)) {
+    return true;
+  }
+
+  if (checker.isTupleType(type)) {
+    return true;
+  }
+
+  const typeString = checker.typeToString(type);
+  if (typedArrayTypes.some((t) => typeString.startsWith(t))) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Checks if a node's type is a string
+ * Returns false if types are unavailable
+ */
+export function isStringType(
+  node: TSESTree.Node,
+  context: Readonly<TSESLint.RuleContext<string, unknown[]>>
+): boolean {
+  const services = tryGetTypedParserServices(context);
+  if (!services) {
+    return false;
+  }
+
+  const type = services.getTypeAtLocation(node);
+  if (!type) {
+    return false;
+  }
+
+  const checker = services.program.getTypeChecker();
+  const stringType = checker.getStringType();
+
+  return checker.isTypeAssignableTo(type, stringType);
+}


### PR DESCRIPTION
This enhances the rule such that, if types are available, we will check
that the variable actually is an array and therefore has an `at` method.

Fixes #45.
