### PR TITLE
feat(prefer-array-some): new rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Read more at the
 |------|-------------|-------------|---------|----------------|
 | [no-indexof-equality](./src/rules/no-indexof-equality.ts) | Prefer `startsWith()` for strings and direct array access over `indexOf()` equality checks | ✖️ | ✅ | ✅ |
 | [prefer-array-from-map](./src/rules/prefer-array-from-map.ts) | Prefer `Array.from(iterable, mapper)` over `[...iterable].map(mapper)` to avoid intermediate array allocation | ✅ | ✅ | ✖️ |
+| [prefer-array-some](./src/rules/prefer-array-some.ts) | Prefer `Array.some()` over `Array.find()` when checking for element existence | ✅ | ✅ | ✖️ |
 | [prefer-timer-args](./src/rules/prefer-timer-args.ts) | Prefer passing function and arguments directly to `setTimeout`/`setInterval` instead of wrapping in an arrow function or using `bind` | ✅ | ✅ | ✖️ |
 | [prefer-date-now](./src/rules/prefer-date-now.ts) | Prefer `Date.now()` over `new Date().getTime()` and `+new Date()` | ✅ | ✅ | ✖️ |
 | [prefer-regex-test](./src/rules/prefer-regex-test.ts) | Prefer `RegExp.test()` over `String.match()` and `RegExp.exec()` when only checking for match existence | ✅ | ✅ | 🔶 |

--- a/src/configs/performance-improvements.ts
+++ b/src/configs/performance-improvements.ts
@@ -10,6 +10,7 @@ export const performanceImprovements = (
     'e18e/prefer-array-from-map': 'error',
     'e18e/prefer-timer-args': 'error',
     'e18e/prefer-date-now': 'error',
-    'e18e/prefer-regex-test': 'error'
+    'e18e/prefer-regex-test': 'error',
+    'e18e/prefer-array-some': 'error'
   }
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import {noIndexOfEquality} from './rules/no-indexof-equality.js';
 import {preferTimerArgs} from './rules/prefer-timer-args.js';
 import {preferDateNow} from './rules/prefer-date-now.js';
 import {preferRegexTest} from './rules/prefer-regex-test.js';
+import {preferArraySome} from './rules/prefer-array-some.js';
 import {rules as dependRules} from 'eslint-plugin-depend';
 
 const plugin: ESLint.Plugin = {
@@ -44,6 +45,7 @@ const plugin: ESLint.Plugin = {
     'prefer-timer-args': preferTimerArgs,
     'prefer-date-now': preferDateNow,
     'prefer-regex-test': preferRegexTest as never as Rule.RuleModule,
+    'prefer-array-some': preferArraySome,
     ...dependRules
   }
 };

--- a/src/rules/prefer-array-some.test.ts
+++ b/src/rules/prefer-array-some.test.ts
@@ -1,0 +1,333 @@
+import {RuleTester} from 'eslint';
+import {preferArraySome} from './prefer-array-some.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('prefer-array-some', preferArraySome, {
+  valid: [
+    'if (arr.some(fn)) {}',
+    'const found = arr.some(fn)',
+    'if (!arr.some(fn)) {}',
+
+    // find calls where the result is used
+    'const item = arr.find(fn)',
+    'const item = arr.find(x => x.id === 1)',
+    'function foo() { return arr.find(fn); }',
+    'obj.item = arr.find(fn)',
+
+    // find with result used in expression
+    'const item = arr.find(fn) || defaultValue',
+    'const name = arr.find(fn)?.name',
+    'processItem(arr.find(fn))',
+
+    // find compared to other values
+    'if (arr.find(fn) === someValue) {}',
+    'if (arr.find(fn) !== someValue) {}',
+
+    // strict equality with null
+    'if (arr.find(fn) === null) {}',
+    'if (arr.find(fn) !== null) {}',
+
+    // loose equality
+    'if (arr.find(fn) == undefined) {}',
+    'if (arr.find(fn) != undefined) {}',
+    'if (arr.find(fn) == null) {}',
+    'if (arr.find(fn) != null) {}'
+  ],
+
+  invalid: [
+    // !arr.find(fn) -> !arr.some(fn)
+    {
+      code: 'if (!arr.find(fn)) {}',
+      output: 'if (!arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 18
+        }
+      ]
+    },
+    {
+      code: 'if (!arr.find(x => x.id === 1)) {}',
+      output: 'if (!arr.some(x => x.id === 1)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    },
+
+    // !!arr.find(fn) -> arr.some(fn)
+    {
+      code: 'if (!!arr.find(fn)) {}',
+      output: 'if (arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
+    {
+      code: 'const exists = !!arr.find(fn);',
+      output: 'const exists = arr.some(fn);',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 16,
+          endLine: 1,
+          endColumn: 30
+        }
+      ]
+    },
+
+    // arr.find(fn) in condition -> arr.some(fn)
+    {
+      code: 'if (arr.find(fn)) {}',
+      output: 'if (arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 17
+        }
+      ]
+    },
+    {
+      code: 'while (arr.find(fn)) {}',
+      output: 'while (arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 8,
+          endLine: 1,
+          endColumn: 20
+        }
+      ]
+    },
+    {
+      code: 'for (; arr.find(fn);) {}',
+      output: 'for (; arr.some(fn);) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 8,
+          endLine: 1,
+          endColumn: 20
+        }
+      ]
+    },
+    {
+      code: 'do {} while (arr.find(fn))',
+      output: 'do {} while (arr.some(fn))',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 26
+        }
+      ]
+    },
+    {
+      code: 'const result = arr.find(fn) ? "yes" : "no";',
+      output: 'const result = arr.some(fn) ? "yes" : "no";',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 16,
+          endLine: 1,
+          endColumn: 28
+        }
+      ]
+    },
+    {
+      code: 'if (arr.find(fn) && otherCondition) {}',
+      output: 'if (arr.some(fn) && otherCondition) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 17
+        }
+      ]
+    },
+    {
+      code: 'if (otherCondition || arr.find(fn)) {}',
+      output: 'if (otherCondition || arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 23,
+          endLine: 1,
+          endColumn: 35
+        }
+      ]
+    },
+
+    // arr.find(fn) === undefined -> !arr.some(fn)
+    {
+      code: 'if (arr.find(fn) === undefined) {}',
+      output: 'if (!arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    },
+    {
+      code: 'if (undefined === arr.find(fn)) {}',
+      output: 'if (!arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    },
+
+    // arr.find(fn) !== undefined -> arr.some(fn)
+    {
+      code: 'if (arr.find(fn) !== undefined) {}',
+      output: 'if (arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    },
+    {
+      code: 'const exists = arr.find(fn) !== undefined;',
+      output: 'const exists = arr.some(fn);',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 16,
+          endLine: 1,
+          endColumn: 42
+        }
+      ]
+    },
+
+    // void 0 (alternative to undefined)
+    {
+      code: 'if (arr.find(fn) === void 0) {}',
+      output: 'if (!arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 28
+        }
+      ]
+    },
+    {
+      code: 'if (arr.find(fn) !== void 0) {}',
+      output: 'if (arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 28
+        }
+      ]
+    },
+
+    // member expressions and what not
+    {
+      code: 'if (this.items.find(fn)) {}',
+      output: 'if (this.items.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 24
+        }
+      ]
+    },
+    {
+      code: 'if (obj.data.arr.find(x => x.id === id)) {}',
+      output: 'if (obj.data.arr.some(x => x.id === id)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 40
+        }
+      ]
+    },
+    {
+      code: 'if (getArray().find(item => item.active)) {}',
+      output: 'if (getArray().some(item => item.active)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 41
+        }
+      ]
+    },
+
+    // with thisArg parameter
+    {
+      code: 'if (arr.find(fn, thisArg)) {}',
+      output: 'if (arr.some(fn, thisArg)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 26
+        }
+      ]
+    }
+  ]
+});

--- a/src/rules/prefer-array-some.ts
+++ b/src/rules/prefer-array-some.ts
@@ -1,0 +1,162 @@
+import type {Rule} from 'eslint';
+import type {
+  BinaryExpression,
+  CallExpression,
+  UnaryExpression,
+  Expression,
+  Node
+} from 'estree';
+import {isInBooleanContext, isNullish} from '../utils/ast.js';
+
+function isFindCall(node: Expression): node is CallExpression {
+  return (
+    node.type === 'CallExpression' &&
+    node.callee.type === 'MemberExpression' &&
+    node.callee.property.type === 'Identifier' &&
+    node.callee.property.name === 'find' &&
+    node.arguments.length >= 1
+  );
+}
+
+function reportFind(
+  context: Rule.RuleContext,
+  node: Node,
+  findCall: CallExpression,
+  shouldNegate: boolean
+) {
+  if (findCall.callee.type !== 'MemberExpression') {
+    return;
+  }
+
+  const sourceCode = context.sourceCode;
+  const arrayText = sourceCode.getText(findCall.callee.object);
+  const argsText = findCall.arguments
+    .map((arg) => sourceCode.getText(arg))
+    .join(', ');
+
+  const replacement = shouldNegate
+    ? `!${arrayText}.some(${argsText})`
+    : `${arrayText}.some(${argsText})`;
+
+  context.report({
+    node,
+    messageId: 'preferArraySome',
+    fix(fixer) {
+      return fixer.replaceText(node, replacement);
+    }
+  });
+}
+
+function checkBinaryExpression(
+  node: BinaryExpression & Rule.NodeParentExtension,
+  context: Rule.RuleContext
+) {
+  const {left, right, operator} = node;
+
+  if (left.type === 'PrivateIdentifier') {
+    return;
+  }
+
+  let findCall: CallExpression;
+  let constantSide: Expression;
+
+  if (isFindCall(left)) {
+    findCall = left;
+    constantSide = right;
+  } else if (isFindCall(right)) {
+    findCall = right;
+    constantSide = left;
+  } else {
+    return;
+  }
+
+  const nullishType = isNullish(constantSide);
+  if (!nullishType) {
+    return;
+  }
+
+  if (operator === '===' || operator === '!==') {
+    if (nullishType !== 'undefined') {
+      return;
+    }
+    const shouldNegate = operator === '===';
+    reportFind(context, node, findCall, shouldNegate);
+    return;
+  }
+}
+
+function checkUnaryExpression(
+  node: UnaryExpression & Rule.NodeParentExtension,
+  context: Rule.RuleContext
+) {
+  // !arr.find(fn) -> !arr.some(fn)
+  if (node.operator === '!' && isFindCall(node.argument)) {
+    reportFind(context, node, node.argument, true);
+    return;
+  }
+
+  // !!arr.find(fn) -> arr.some(fn)
+  if (
+    node.operator === '!' &&
+    node.argument.type === 'UnaryExpression' &&
+    node.argument.operator === '!' &&
+    isFindCall(node.argument.argument)
+  ) {
+    reportFind(context, node, node.argument.argument, false);
+    return;
+  }
+}
+
+export const preferArraySome: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer Array.some() over Array.find() when checking for element existence',
+      recommended: true
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      preferArraySome:
+        'Use Array.some() instead of Array.find() when checking for element existence'
+    }
+  },
+  create(context) {
+    return {
+      BinaryExpression(node: BinaryExpression & Rule.NodeParentExtension) {
+        checkBinaryExpression(node, context);
+      },
+      UnaryExpression(node: UnaryExpression & Rule.NodeParentExtension) {
+        // Skip inner ! if it's inside !! (the outer will handle it)
+        if (node.operator === '!' && node.parent) {
+          if (
+            node.parent.type === 'UnaryExpression' &&
+            node.parent.operator === '!'
+          ) {
+            return;
+          }
+        }
+
+        checkUnaryExpression(node, context);
+      },
+      CallExpression(node: CallExpression & Rule.NodeParentExtension) {
+        // Skip if handled by UnaryExpression or BinaryExpression
+        if (
+          node.parent?.type === 'UnaryExpression' ||
+          node.parent?.type === 'BinaryExpression'
+        ) {
+          return;
+        }
+
+        if (!isFindCall(node)) {
+          return;
+        }
+
+        if (isInBooleanContext(node)) {
+          reportFind(context, node, node, false);
+        }
+      }
+    };
+  }
+};

--- a/src/rules/prefer-regex-test.ts
+++ b/src/rules/prefer-regex-test.ts
@@ -1,5 +1,6 @@
 import type {TSESLint, TSESTree} from '@typescript-eslint/utils';
 import {tryGetTypedParserServices} from '../utils/typescript.js';
+import {isInBooleanContext} from '../utils/ast.js';
 
 type MessageIds = 'preferTest';
 
@@ -111,43 +112,6 @@ function resolvesToRegExp(
         return true;
       }
     }
-  }
-
-  return false;
-}
-
-/**
- * Checks if a node is in a test/condition
- */
-function isInBooleanContext(node: TSESTree.Node): boolean {
-  const parent = node.parent;
-
-  if (!parent) {
-    return false;
-  }
-
-  // if/while/for/do-while test
-  if (
-    (parent.type === 'IfStatement' && parent.test === node) ||
-    (parent.type === 'WhileStatement' && parent.test === node) ||
-    (parent.type === 'ForStatement' && parent.test === node) ||
-    (parent.type === 'DoWhileStatement' && parent.test === node)
-  ) {
-    return true;
-  }
-
-  // ternaries
-  if (parent.type === 'ConditionalExpression' && parent.test === node) {
-    return true;
-  }
-
-  // check the parent
-  if (
-    (parent.type === 'UnaryExpression' && parent.operator === '!') ||
-    (parent.type === 'LogicalExpression' &&
-      (parent.operator === '&&' || parent.operator === '||'))
-  ) {
-    return isInBooleanContext(parent);
   }
 
   return false;


### PR DESCRIPTION
This prefers `arr.some(fn)` over things like `!arr.find(fn)`.

Closes #36.
