### PR TITLE
chore: support ESLint 10.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,16 @@
         "vitest": "^4.0.14"
       },
       "peerDependencies": {
-        "eslint": "^9.0.0"
+        "eslint": "^9.0.0 || ^10.0.0",
+        "oxlint": "^1.41.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        },
+        "oxlint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "vitest": "^4.0.14"
   },
   "peerDependencies": {
-    "eslint": "^9.0.0",
+    "eslint": "^9.0.0 || ^10.0.0",
     "oxlint": "^1.41.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Nothing really changes for us as it already supports our plugin. We just
need to bump the range.

Fixes #62 