### PR TITLE
feat: new rule prefer-static-regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Read more at the
 | [prefer-timer-args](./src/rules/prefer-timer-args.ts) | Prefer passing function and arguments directly to `setTimeout`/`setInterval` instead of wrapping in an arrow function or using `bind` | ✅ | ✅ | ✖️ |
 | [prefer-date-now](./src/rules/prefer-date-now.ts) | Prefer `Date.now()` over `new Date().getTime()` and `+new Date()` | ✅ | ✅ | ✖️ |
 | [prefer-regex-test](./src/rules/prefer-regex-test.ts) | Prefer `RegExp.test()` over `String.match()` and `RegExp.exec()` when only checking for match existence | ✅ | ✅ | 🔶 |
+| [prefer-static-regex](./src/rules/prefer-static-regex.ts) | Prefer defining regular expressions at module scope to avoid re-compilation on every function call | ✅ | ✖️ | ✖️ |
 
 ## Sponsors
 

--- a/src/configs/performance-improvements.ts
+++ b/src/configs/performance-improvements.ts
@@ -11,6 +11,7 @@ export const performanceImprovements = (
     'e18e/prefer-timer-args': 'error',
     'e18e/prefer-date-now': 'error',
     'e18e/prefer-regex-test': 'error',
-    'e18e/prefer-array-some': 'error'
+    'e18e/prefer-array-some': 'error',
+    'e18e/prefer-static-regex': 'error'
   }
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import {preferTimerArgs} from './rules/prefer-timer-args.js';
 import {preferDateNow} from './rules/prefer-date-now.js';
 import {preferRegexTest} from './rules/prefer-regex-test.js';
 import {preferArraySome} from './rules/prefer-array-some.js';
+import {preferStaticRegex} from './rules/prefer-static-regex.js';
 import {rules as dependRules} from 'eslint-plugin-depend';
 
 const plugin: ESLint.Plugin = {
@@ -46,6 +47,7 @@ const plugin: ESLint.Plugin = {
     'prefer-date-now': preferDateNow,
     'prefer-regex-test': preferRegexTest as never as Rule.RuleModule,
     'prefer-array-some': preferArraySome,
+    'prefer-static-regex': preferStaticRegex,
     ...dependRules
   }
 };

--- a/src/rules/prefer-static-regex.test.ts
+++ b/src/rules/prefer-static-regex.test.ts
@@ -1,0 +1,182 @@
+import {RuleTester} from 'eslint';
+import {preferStaticRegex} from './prefer-static-regex.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('prefer-static-regex', preferStaticRegex, {
+  valid: [
+    'const RE = /foo/;',
+    'const RE = /foo/gi;',
+    'const RE = new RegExp("foo");',
+    'const RE = new RegExp("foo", "g");',
+
+    // Dynamic regex
+    'function f(p) { return new RegExp(p); }',
+    'function f(p) { return new RegExp(p, "g"); }',
+    'function f(p) { return new RegExp("foo" + p); }',
+
+    // Not inside a function
+    '/foo/.test("bar");',
+    'new RegExp("foo").test("bar");',
+
+    // new RegExp with no args
+    'function f() { return new RegExp(); }'
+  ],
+  invalid: [
+    // function declaration
+    {
+      code: 'function f(s) { return /foo/.test(s); }',
+      errors: [
+        {
+          messageId: 'preferStatic',
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 29
+        }
+      ]
+    },
+    // arrow function
+    {
+      code: 'const f = (s) => /foo/.test(s);',
+      errors: [
+        {
+          messageId: 'preferStatic',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 23
+        }
+      ]
+    },
+    // function expression
+    {
+      code: 'const f = function(s) { return /foo/.test(s); };',
+      errors: [
+        {
+          messageId: 'preferStatic',
+          line: 1,
+          column: 32,
+          endLine: 1,
+          endColumn: 37
+        }
+      ]
+    },
+    // class method
+    {
+      code: 'class C { m(s) { return /foo/.test(s); } }',
+      errors: [
+        {
+          messageId: 'preferStatic',
+          line: 1,
+          column: 25,
+          endLine: 1,
+          endColumn: 30
+        }
+      ]
+    },
+    // with flags
+    {
+      code: 'function f(s) { return /foo/gi.test(s); }',
+      errors: [
+        {
+          messageId: 'preferStatic',
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    },
+    // with string literal in function
+    {
+      code: 'function f(s) { return new RegExp("foo").test(s); }',
+      errors: [
+        {
+          messageId: 'preferStatic',
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 41
+        }
+      ]
+    },
+    // with string literal and flags in function
+    {
+      code: 'function f(s) { return new RegExp("foo", "gi").test(s); }',
+      errors: [
+        {
+          messageId: 'preferStatic',
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 47
+        }
+      ]
+    },
+    // assigned to const inside function
+    {
+      code: 'function f(s) { const re = /foo/; return re.test(s); }',
+      errors: [
+        {
+          messageId: 'preferStatic',
+          line: 1,
+          column: 28,
+          endLine: 1,
+          endColumn: 33
+        }
+      ]
+    },
+    // Nested function
+    {
+      code: 'function outer() { function inner(s) { return /foo/.test(s); } }',
+      errors: [
+        {
+          messageId: 'preferStatic',
+          line: 1,
+          column: 47,
+          endLine: 1,
+          endColumn: 52
+        }
+      ]
+    },
+    // Multiple regexes in same function
+    {
+      code: 'function f(s) { /foo/.test(s); /bar/.test(s); }',
+      errors: [
+        {
+          messageId: 'preferStatic',
+          line: 1,
+          column: 17,
+          endLine: 1,
+          endColumn: 22
+        },
+        {
+          messageId: 'preferStatic',
+          line: 1,
+          column: 32,
+          endLine: 1,
+          endColumn: 37
+        }
+      ]
+    },
+    // Regex in string replace
+    {
+      code: 'function f(s) { return s.replace(/foo/g, "bar"); }',
+      errors: [
+        {
+          messageId: 'preferStatic',
+          line: 1,
+          column: 34,
+          endLine: 1,
+          endColumn: 40
+        }
+      ]
+    }
+  ]
+});

--- a/src/rules/prefer-static-regex.ts
+++ b/src/rules/prefer-static-regex.ts
@@ -1,0 +1,47 @@
+import type {Rule} from 'eslint';
+import type {NewExpression} from 'estree';
+
+function isStaticNewRegExp(node: NewExpression): boolean {
+  if (
+    node.callee.type !== 'Identifier' ||
+    node.callee.name !== 'RegExp' ||
+    node.arguments.length === 0 ||
+    node.arguments.length > 2
+  ) {
+    return false;
+  }
+
+  return node.arguments.every(
+    (arg) => arg.type === 'Literal' && typeof arg.value === 'string'
+  );
+}
+
+export const preferStaticRegex: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer defining regular expressions at module scope to avoid re-compilation on every function call',
+      recommended: true
+    },
+    schema: [],
+    messages: {
+      preferStatic:
+        'Move this regular expression to module scope to avoid re-compilation on every call.'
+    }
+  },
+  create(context) {
+    return {
+      ':function Literal[regex]'(node: Rule.Node) {
+        context.report({node, messageId: 'preferStatic'});
+      },
+      ':function NewExpression'(
+        node: NewExpression & Rule.NodeParentExtension
+      ) {
+        if (isStaticNewRegExp(node)) {
+          context.report({node, messageId: 'preferStatic'});
+        }
+      }
+    };
+  }
+};


### PR DESCRIPTION
This rule prefers module-level regex constants over inline literals.

For example:

```ts
// Bad
function f(val) {
  return /foo/.test(val);
}

// Good
const FOO_PATTERN = /foo/;

function f(val) {
  return FOO_PATTERN.test(val);
}
```

No fixer (for now) as it is a fairly disruptive change to fix.
