### PR TITLE
feat: new rule `prefer-inline-equality`

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Read more at the
 | [prefer-date-now](./src/rules/prefer-date-now.ts) | Prefer `Date.now()` over `new Date().getTime()` and `+new Date()` | ✅ | ✅ | ✖️ |
 | [prefer-regex-test](./src/rules/prefer-regex-test.ts) | Prefer `RegExp.test()` over `String.match()` and `RegExp.exec()` when only checking for match existence | ✅ | ✅ | 🔶 |
 | [prefer-static-regex](./src/rules/prefer-static-regex.ts) | Prefer defining regular expressions at module scope to avoid re-compilation on every function call | ✅ | ✖️ | ✖️ |
+| [prefer-inline-equality](./src/rules/prefer-inline-equality.ts) | Prefer inline equality checks over temporary object creation for simple comparisons | ✅ | ✅ | 🔶 |
 
 ## Sponsors
 

--- a/src/configs/performance-improvements.ts
+++ b/src/configs/performance-improvements.ts
@@ -12,6 +12,7 @@ export const performanceImprovements = (
     'e18e/prefer-date-now': 'error',
     'e18e/prefer-regex-test': 'error',
     'e18e/prefer-array-some': 'error',
-    'e18e/prefer-static-regex': 'error'
+    'e18e/prefer-static-regex': 'error',
+    'e18e/prefer-inline-equality': 'error'
   }
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import {preferDateNow} from './rules/prefer-date-now.js';
 import {preferRegexTest} from './rules/prefer-regex-test.js';
 import {preferArraySome} from './rules/prefer-array-some.js';
 import {preferStaticRegex} from './rules/prefer-static-regex.js';
+import {preferInlineEquality} from './rules/prefer-inline-equality.js';
 import {rules as dependRules} from 'eslint-plugin-depend';
 
 const plugin: ESLint.Plugin = {
@@ -48,6 +49,7 @@ const plugin: ESLint.Plugin = {
     'prefer-regex-test': preferRegexTest as never as Rule.RuleModule,
     'prefer-array-some': preferArraySome,
     'prefer-static-regex': preferStaticRegex,
+    'prefer-inline-equality': preferInlineEquality as never as Rule.RuleModule,
     ...dependRules
   }
 };

--- a/src/rules/prefer-inline-equality.test.ts
+++ b/src/rules/prefer-inline-equality.test.ts
@@ -1,0 +1,369 @@
+import {RuleTester} from 'eslint';
+import {RuleTester as TSRuleTester} from '@typescript-eslint/rule-tester';
+import {preferInlineEquality} from './prefer-inline-equality.js';
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const rootDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..'
+);
+const typedRuleTester = new TSRuleTester({
+  languageOptions: {
+    parserOptions: {
+      projectService: {
+        allowDefaultProject: ['*.ts'],
+        defaultProject: './tsconfig.json'
+      },
+      tsconfigRootDir: rootDir
+    }
+  }
+});
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run(
+  'prefer-inline-equality (untyped)',
+  preferInlineEquality as never,
+  {
+    valid: [
+      'arr.includes(x)',
+
+      // empty
+      '[].includes(x)',
+
+      // too many elements
+      '[a, b, c, d, e, f, g].includes(x)',
+
+      // NaN
+      '[NaN, a].includes(x)',
+
+      // val is a call expression (side effects)
+      '[a, b].includes(foo())',
+
+      // Element is a call expression
+      '[foo(), b].includes(x)',
+
+      // Spread without types (should be skipped)
+      '[...a, b].includes(x)',
+
+      // Sparse array
+      '[a, , b].includes(x)',
+
+      // No arguments
+      '[a, b].includes()',
+
+      // Multiple arguments
+      '[a, b].includes(x, 0)',
+
+      // Computed property
+      '[a, b][method](x)'
+    ],
+    invalid: [
+      // Basic two elements
+      {
+        code: '[a, b].includes(x)',
+        output: 'a === x || b === x',
+        errors: [
+          {
+            messageId: 'preferEquality',
+            line: 1,
+            column: 1,
+            endLine: 1,
+            endColumn: 19
+          }
+        ]
+      },
+      // Three elements with literals
+      {
+        code: '[1, 2, 3].includes(x)',
+        output: '1 === x || 2 === x || 3 === x',
+        errors: [
+          {
+            messageId: 'preferEquality',
+            line: 1,
+            column: 1,
+            endLine: 1,
+            endColumn: 22
+          }
+        ]
+      },
+      // String literals
+      {
+        code: '["a", "b"].includes(x)',
+        output: '"a" === x || "b" === x',
+        errors: [
+          {
+            messageId: 'preferEquality',
+            line: 1,
+            column: 1,
+            endLine: 1,
+            endColumn: 23
+          }
+        ]
+      },
+      // Mixed identifiers and literals
+      {
+        code: '[a, 1, "b"].includes(x)',
+        output: 'a === x || 1 === x || "b" === x',
+        errors: [
+          {
+            messageId: 'preferEquality',
+            line: 1,
+            column: 1,
+            endLine: 1,
+            endColumn: 24
+          }
+        ]
+      },
+      // Negated
+      {
+        code: '![a, b].includes(x)',
+        output: 'a !== x && b !== x',
+        errors: [
+          {
+            messageId: 'preferEquality',
+            line: 1,
+            column: 1,
+            endLine: 1,
+            endColumn: 20
+          }
+        ]
+      },
+      // val is a member expression (safe to repeat)
+      {
+        code: '[a, b].includes(obj.prop)',
+        output: 'a === obj.prop || b === obj.prop',
+        errors: [
+          {
+            messageId: 'preferEquality',
+            line: 1,
+            column: 1,
+            endLine: 1,
+            endColumn: 26
+          }
+        ]
+      },
+      // Wraps in parens when used as argument
+      {
+        code: 'foo([a, b].includes(x))',
+        output: 'foo((a === x || b === x))',
+        errors: [
+          {
+            messageId: 'preferEquality',
+            line: 1,
+            column: 5,
+            endLine: 1,
+            endColumn: 23
+          }
+        ]
+      },
+      // Wraps in parens when used in logical expression
+      {
+        code: '[a, b].includes(x) && y',
+        output: '(a === x || b === x) && y',
+        errors: [
+          {
+            messageId: 'preferEquality',
+            line: 1,
+            column: 1,
+            endLine: 1,
+            endColumn: 19
+          }
+        ]
+      },
+      // Single element
+      {
+        code: '[a].includes(x)',
+        output: 'a === x',
+        errors: [
+          {
+            messageId: 'preferEquality',
+            line: 1,
+            column: 1,
+            endLine: 1,
+            endColumn: 16
+          }
+        ]
+      },
+      // Negated in logical expression
+      {
+        code: '![a, b].includes(x) && y',
+        output: '(a !== x && b !== x) && y',
+        errors: [
+          {
+            messageId: 'preferEquality',
+            line: 1,
+            column: 1,
+            endLine: 1,
+            endColumn: 20
+          }
+        ]
+      }
+    ]
+  }
+);
+
+typedRuleTester.run('prefer-inline-equality (typed)', preferInlineEquality, {
+  valid: [
+    // Spread of non-array type (string)
+    {
+      code: `
+        const s: string = "abc";
+        [a, ...s].includes(x);
+      `
+    },
+    // Spread of unknown iterable type
+    {
+      code: `
+        function foo(s: Iterable<number>) {
+          [...s].includes(x);
+        }
+      `
+    }
+  ],
+  invalid: [
+    // Spread of array type
+    {
+      code: `
+        const arr: number[] = [1, 2, 3];
+        [...arr].includes(x);
+      `,
+      output: `
+        const arr: number[] = [1, 2, 3];
+        arr.includes(x);
+      `,
+      errors: [
+        {
+          messageId: 'preferEquality',
+          line: 3,
+          column: 9,
+          endLine: 3,
+          endColumn: 29
+        }
+      ]
+    },
+    // Mixed elements and spread
+    {
+      code: `
+        const arr: number[] = [1, 2, 3];
+        [a, ...arr, b].includes(x);
+      `,
+      output: `
+        const arr: number[] = [1, 2, 3];
+        a === x || arr.includes(x) || b === x;
+      `,
+      errors: [
+        {
+          messageId: 'preferEquality',
+          line: 3,
+          column: 9,
+          endLine: 3,
+          endColumn: 35
+        }
+      ]
+    },
+    // Negated with spread
+    {
+      code: `
+        const arr: number[] = [1, 2, 3];
+        ![a, ...arr].includes(x);
+      `,
+      output: `
+        const arr: number[] = [1, 2, 3];
+        a !== x && !arr.includes(x);
+      `,
+      errors: [
+        {
+          messageId: 'preferEquality',
+          line: 3,
+          column: 9,
+          endLine: 3,
+          endColumn: 33
+        }
+      ]
+    },
+    // Spread of Set type
+    {
+      code: `
+        const s = new Set([1, 2, 3]);
+        [...s].includes(x);
+      `,
+      output: `
+        const s = new Set([1, 2, 3]);
+        s.has(x);
+      `,
+      errors: [
+        {
+          messageId: 'preferEquality',
+          line: 3,
+          column: 9,
+          endLine: 3,
+          endColumn: 27
+        }
+      ]
+    },
+    // Mixed elements and Set spread
+    {
+      code: `
+        const s = new Set([1, 2, 3]);
+        [a, ...s].includes(x);
+      `,
+      output: `
+        const s = new Set([1, 2, 3]);
+        a === x || s.has(x);
+      `,
+      errors: [
+        {
+          messageId: 'preferEquality',
+          line: 3,
+          column: 9,
+          endLine: 3,
+          endColumn: 30
+        }
+      ]
+    },
+    // Negated Set spread
+    {
+      code: `
+        const s = new Set([1, 2, 3]);
+        ![...s].includes(x);
+      `,
+      output: `
+        const s = new Set([1, 2, 3]);
+        !s.has(x);
+      `,
+      errors: [
+        {
+          messageId: 'preferEquality',
+          line: 3,
+          column: 9,
+          endLine: 3,
+          endColumn: 28
+        }
+      ]
+    },
+    // Basic case still works with types
+    {
+      code: `
+        [a, b].includes(x);
+      `,
+      output: `
+        a === x || b === x;
+      `,
+      errors: [
+        {
+          messageId: 'preferEquality',
+          line: 2,
+          column: 9,
+          endLine: 2,
+          endColumn: 27
+        }
+      ]
+    }
+  ]
+});

--- a/src/rules/prefer-inline-equality.ts
+++ b/src/rules/prefer-inline-equality.ts
@@ -1,0 +1,216 @@
+import type {TSESLint, TSESTree} from '@typescript-eslint/utils';
+import {
+  isArrayType,
+  isSetType,
+  tryGetTypedParserServices
+} from '../utils/typescript.js';
+
+type MessageIds = 'preferEquality';
+
+/**
+ * Checks if a node is safe to repeat (i.e. no side effects)
+ */
+function isSafeToRepeat(node: TSESTree.Node): boolean {
+  if (node.type === 'Identifier') {
+    return true;
+  }
+  if (node.type === 'Literal') {
+    return true;
+  }
+  if (node.type === 'TemplateLiteral' && node.expressions.length === 0) {
+    return true;
+  }
+  if (node.type === 'MemberExpression' && !node.computed) {
+    return isSafeToRepeat(node.object);
+  }
+  return false;
+}
+
+/**
+ * Checks if a node is NaN
+ */
+function isNaN(node: TSESTree.Node): boolean {
+  return node.type === 'Identifier' && node.name === 'NaN';
+}
+
+/**
+ * Checks if an array element is an identifier or literal
+ */
+function isSimpleElement(node: TSESTree.Node): boolean {
+  if (isNaN(node)) {
+    return false;
+  }
+  return node.type === 'Identifier' || node.type === 'Literal';
+}
+
+/**
+ * Checks if the node is negated
+ */
+function isNegated(node: TSESTree.Node): boolean {
+  return (
+    node.parent !== undefined &&
+    node.parent.type === 'UnaryExpression' &&
+    node.parent.operator === '!'
+  );
+}
+
+/**
+ * Checks if the replacement expression needs to be wrapped in parentheses
+ * based on the parent node context
+ */
+function needsParentheses(node: TSESTree.Node): boolean {
+  if (!node.parent) {
+    return false;
+  }
+
+  switch (node.parent.type) {
+    case 'CallExpression':
+    case 'NewExpression':
+    case 'MemberExpression':
+    case 'ConditionalExpression':
+    case 'BinaryExpression':
+    case 'LogicalExpression':
+    case 'UnaryExpression':
+    case 'TaggedTemplateExpression':
+    case 'SpreadElement':
+    case 'AwaitExpression':
+      return true;
+    default:
+      return false;
+  }
+}
+
+function checkArrayIncludes(
+  node: TSESTree.CallExpression,
+  context: TSESLint.RuleContext<MessageIds, []>
+): void {
+  const {callee} = node;
+
+  if (callee.type !== 'MemberExpression') {
+    return;
+  }
+
+  const property = callee.property;
+
+  if (
+    property.type !== 'Identifier' ||
+    property.name !== 'includes' ||
+    callee.computed
+  ) {
+    return;
+  }
+
+  if (node.arguments.length !== 1) {
+    return;
+  }
+
+  const arrayNode = callee.object;
+
+  if (arrayNode.type !== 'ArrayExpression') {
+    return;
+  }
+
+  const elements = arrayNode.elements;
+
+  if (elements.length === 0 || elements.length > 6) {
+    return;
+  }
+
+  const val = node.arguments[0]!;
+
+  if (!isSafeToRepeat(val)) {
+    return;
+  }
+
+  const hasTypes = tryGetTypedParserServices(context) !== null;
+
+  for (const element of elements) {
+    if (element === null) {
+      return;
+    }
+
+    if (element.type === 'SpreadElement') {
+      const arg = element.argument;
+      if (!isSafeToRepeat(arg)) {
+        return;
+      }
+      if (
+        !hasTypes ||
+        (!isArrayType(arg, context) && !isSetType(arg, context))
+      ) {
+        return;
+      }
+    } else if (!isSimpleElement(element)) {
+      return;
+    }
+  }
+
+  const sourceCode = context.sourceCode;
+  const negated = isNegated(node);
+
+  const operator = negated ? '!==' : '===';
+  const joiner = negated ? ' && ' : ' || ';
+
+  const parts: string[] = [];
+
+  for (const element of elements) {
+    if (element === null) {
+      return;
+    }
+
+    if (element.type === 'SpreadElement') {
+      const argText = sourceCode.getText(element.argument);
+      const valText = sourceCode.getText(val);
+      const method = isSetType(element.argument, context) ? 'has' : 'includes';
+      if (negated) {
+        parts.push(`!${argText}.${method}(${valText})`);
+      } else {
+        parts.push(`${argText}.${method}(${valText})`);
+      }
+    } else {
+      const elemText = sourceCode.getText(element);
+      const valText = sourceCode.getText(val);
+      parts.push(`${elemText} ${operator} ${valText}`);
+    }
+  }
+
+  const replacement = parts.join(joiner);
+
+  const reportNode = negated ? node.parent : node;
+
+  const needsParens = needsParentheses(reportNode);
+  const fixText = needsParens ? `(${replacement})` : replacement;
+
+  context.report({
+    node: reportNode,
+    messageId: 'preferEquality',
+    fix(fixer) {
+      return fixer.replaceText(reportNode, fixText);
+    }
+  });
+}
+
+export const preferInlineEquality: TSESLint.RuleModule<MessageIds, []> = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer inline equality checks over temporary object creation for simple comparisons'
+    },
+    fixable: 'code',
+    messages: {
+      preferEquality:
+        'Avoid creating a temporary array just to call `.includes()`. Use equality checks instead.'
+    },
+    schema: []
+  },
+  defaultOptions: [],
+
+  create(context) {
+    return {
+      CallExpression(node: TSESTree.CallExpression) {
+        checkArrayIncludes(node, context);
+      }
+    };
+  }
+};

--- a/src/utils/typescript.ts
+++ b/src/utils/typescript.ts
@@ -91,6 +91,32 @@ export function isArrayType(
   return false;
 }
 
+const setTypePattern = /^(Readonly)?Set</;
+
+/**
+ * Checks if a node's type is a Set
+ * Returns true if types are unavailable (to avoid false negatives)
+ */
+export function isSetType(
+  node: TSESTree.Node,
+  context: Readonly<TSESLint.RuleContext<string, unknown[]>>
+): boolean {
+  const services = tryGetTypedParserServices(context);
+  if (!services) {
+    return true;
+  }
+
+  const type = services.getTypeAtLocation(node);
+  if (!type) {
+    return true;
+  }
+
+  const checker = services.program.getTypeChecker();
+  const typeString = checker.typeToString(type);
+
+  return setTypePattern.test(typeString);
+}
+
 /**
  * Checks if a node's type is a string
  * Returns false if types are unavailable


### PR DESCRIPTION
Prefers inline equality over temporary object allocation. Only arrays
for now.

For example:

```ts
// Bad
[a, b, c].includes(val);

// Good
a === val || b === val || c === val;
```
