### PR TITLE
feat: adopt ban-dependencies rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /lib
+/coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "eslint-plugin-depend": "^1.5.0"
+        "empathic": "^2.0.0",
+        "module-replacements": "^3.0.0-beta.4",
+        "semver": "^7.6.3"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -138,6 +140,7 @@
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
       "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
@@ -156,6 +159,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -168,6 +172,7 @@
       "version": "4.12.2",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -177,6 +182,7 @@
       "version": "0.23.3",
       "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
       "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^3.0.3",
@@ -191,6 +197,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
       "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^1.1.1"
@@ -203,6 +210,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
       "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
@@ -252,6 +260,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
       "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -261,6 +270,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
       "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^1.1.1",
@@ -274,6 +284,7 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
@@ -283,6 +294,7 @@
       "version": "0.16.7",
       "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
       "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/core": "^0.19.1",
@@ -296,6 +308,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
@@ -319,6 +332,7 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
@@ -1018,18 +1032,21 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
       "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1446,6 +1463,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -1458,6 +1476,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -1467,6 +1486,7 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -1505,6 +1525,7 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
       "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -1517,6 +1538,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -1543,6 +1565,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1557,6 +1580,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1574,6 +1598,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
@@ -1606,6 +1631,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1618,6 +1644,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
       "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
@@ -1669,20 +1696,6 @@
         }
       }
     },
-    "node_modules/eslint-plugin-depend": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-depend/-/eslint-plugin-depend-1.5.0.tgz",
-      "integrity": "sha512-i3UeLYmclf1Icp35+6W7CR4Bp2PIpDgBuf/mpmXK5UeLkZlvYJ21VuQKKHHAIBKRTPivPGX/gZl5JGno1o9Y0A==",
-      "license": "MIT",
-      "dependencies": {
-        "empathic": "^2.0.0",
-        "module-replacements": "^2.10.1",
-        "semver": "^7.6.3"
-      },
-      "peerDependencies": {
-        "eslint": ">=8.40.0"
-      }
-    },
     "node_modules/eslint-plugin-eslint-plugin": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-7.3.2.tgz",
@@ -1704,6 +1717,7 @@
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
       "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/esrecurse": "^4.3.1",
@@ -1722,6 +1736,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -1734,6 +1749,7 @@
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
       "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.16.0",
@@ -1751,6 +1767,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -1763,6 +1780,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -1775,6 +1793,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -1794,6 +1813,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -1813,18 +1833,21 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fdir": {
@@ -1849,6 +1872,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^4.0.0"
@@ -1861,6 +1885,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -1877,6 +1902,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
@@ -1890,6 +1916,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -1911,6 +1938,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -1940,6 +1968,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -1949,6 +1978,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -1958,6 +1988,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1967,6 +1998,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -1979,6 +2011,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -2031,18 +2064,21 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonc-eslint-parser": {
@@ -2067,6 +2103,7 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -2076,6 +2113,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -2350,6 +2388,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -2410,6 +2449,7 @@
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
       "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
@@ -2422,15 +2462,16 @@
       }
     },
     "node_modules/module-replacements": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/module-replacements/-/module-replacements-2.10.1.tgz",
-      "integrity": "sha512-qkKuLpMHDqRSM676OPL7HUpCiiP3NSxgf8NNR1ga2h/iJLNKTsOSjMEwrcT85DMSti2vmOqxknOVBGWj6H6etQ==",
+      "version": "3.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/module-replacements/-/module-replacements-3.0.0-beta.4.tgz",
+      "integrity": "sha512-rk0623vx0G4IxCeU/TpuAQ5WAQ/dNtHV+zCT6BmZMXf3Oym0NGOcIzUbJyhFRtky3PHLRmhEZ/JkthNqliS+7Q==",
       "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2456,6 +2497,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/obug": {
@@ -2473,6 +2515,7 @@
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
@@ -2535,6 +2578,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -2550,6 +2594,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -2565,6 +2610,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2574,6 +2620,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2639,6 +2686,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -2664,6 +2712,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2719,6 +2768,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -2731,6 +2781,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2849,6 +2900,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -2906,6 +2958,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -3076,6 +3129,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -3108,6 +3162,7 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3117,6 +3172,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,13 @@
       "dependencies": {
         "empathic": "^2.0.0",
         "module-replacements": "^3.0.0-beta.4",
-        "semver": "^7.6.3"
+        "semver": "^7.7.4"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@eslint/json": "^1.2.0",
         "@types/node": "^25.6.0",
+        "@types/semver": "^7.7.1",
         "@typescript-eslint/rule-tester": "^8.58.1",
         "@typescript-eslint/typescript-estree": "^8.58.1",
         "@vitest/coverage-v8": "^4.1.4",
@@ -1052,6 +1053,13 @@
       "dependencies": {
         "undici-types": "~7.19.0"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.1",
@@ -2761,9 +2769,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
     }
   },
   "dependencies": {
-    "eslint-plugin-depend": "^1.5.0"
+    "empathic": "^2.0.0",
+    "module-replacements": "^3.0.0-beta.4",
+    "semver": "^7.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@eslint/js": "^10.0.1",
     "@eslint/json": "^1.2.0",
     "@types/node": "^25.6.0",
+    "@types/semver": "^7.7.1",
     "@typescript-eslint/rule-tester": "^8.58.1",
     "@typescript-eslint/typescript-estree": "^8.58.1",
     "@vitest/coverage-v8": "^4.1.4",
@@ -65,6 +66,6 @@
   "dependencies": {
     "empathic": "^2.0.0",
     "module-replacements": "^3.0.0-beta.4",
-    "semver": "^7.6.3"
+    "semver": "^7.7.4"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ import {preferRegexTest} from './rules/prefer-regex-test.js';
 import {preferArraySome} from './rules/prefer-array-some.js';
 import {preferStaticRegex} from './rules/prefer-static-regex.js';
 import {preferInlineEquality} from './rules/prefer-inline-equality.js';
-import {rules as dependRules} from 'eslint-plugin-depend';
+import {banDependencies} from './rules/ban-dependencies.js';
 
 const plugin: ESLint.Plugin = {
   meta: {
@@ -50,7 +50,7 @@ const plugin: ESLint.Plugin = {
     'prefer-array-some': preferArraySome,
     'prefer-static-regex': preferStaticRegex,
     'prefer-inline-equality': preferInlineEquality as never as Rule.RuleModule,
-    ...dependRules
+    'ban-dependencies': banDependencies
   }
 };
 

--- a/src/rules/ban-dependencies.test.ts
+++ b/src/rules/ban-dependencies.test.ts
@@ -1,12 +1,25 @@
-import {run, runClassic} from 'eslint-vitest-rule-tester';
+import {RuleTester} from 'eslint';
 import * as tseslintParser from '@typescript-eslint/parser';
 import * as jsonParser from 'jsonc-eslint-parser';
 import eslintJson from '@eslint/json';
+import {resolveDocUrl} from 'module-replacements';
+import {banDependencies} from './ban-dependencies.js';
 
-import {rule} from '../../rules/ban-dependencies.js';
-import {getMdnUrl, getReplacementsDocUrl} from '../../util/rule-meta.js';
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module'
+  }
+});
+const jsonRuleTester = new RuleTester({
+  files: ['**/*.json'],
+  language: 'json/json',
+  plugins: {
+    json: eslintJson
+  }
+});
 
-await runClassic('ban-dependencies', rule, {
+ruleTester.run('ban-dependencies', banDependencies, {
   valid: [
     'const foo = 303;',
     {
@@ -104,7 +117,8 @@ await runClassic('ban-dependencies', rule, {
           messageId: 'simpleReplacement',
           data: {
             name: 'is-number',
-            replacement: `Use typeof v === "number" || (typeof v === "string" && Number.isFinite(+v))`
+            description:
+              'You can check if a value is a number by using `typeof` or coercing it to a number and using `Number.isFinite`.'
           }
         }
       ]
@@ -118,7 +132,8 @@ await runClassic('ban-dependencies', rule, {
           messageId: 'simpleReplacement',
           data: {
             name: 'is-number',
-            replacement: `Use typeof v === "number" || (typeof v === "string" && Number.isFinite(+v))`
+            description:
+              'You can check if a value is a number by using `typeof` or coercing it to a number and using `Number.isFinite`.'
           }
         }
       ]
@@ -132,7 +147,8 @@ await runClassic('ban-dependencies', rule, {
           messageId: 'simpleReplacement',
           data: {
             name: 'is-number',
-            replacement: `Use typeof v === "number" || (typeof v === "string" && Number.isFinite(+v))`
+            description:
+              'You can check if a value is a number by using `typeof` or coercing it to a number and using `Number.isFinite`.'
           }
         }
       ]
@@ -149,7 +165,8 @@ await runClassic('ban-dependencies', rule, {
           messageId: 'simpleReplacement',
           data: {
             name: 'is-number',
-            replacement: `Use typeof v === "number" || (typeof v === "string" && Number.isFinite(+v))`
+            description:
+              'You can check if a value is a number by using `typeof` or coercing it to a number and using `Number.isFinite`.'
           }
         }
       ]
@@ -164,7 +181,10 @@ await runClassic('ban-dependencies', rule, {
           data: {
             name: 'object.entries',
             replacement: 'Object.entries',
-            url: getMdnUrl('Global_Objects/Object/entries')
+            url: resolveDocUrl({
+              type: 'mdn',
+              id: 'Web/JavaScript/Reference/Global_Objects/Object/entries'
+            })
           }
         }
       ]
@@ -178,7 +198,8 @@ await runClassic('ban-dependencies', rule, {
           messageId: 'documentedReplacement',
           data: {
             name: 'npm-run-all',
-            url: getReplacementsDocUrl('npm-run-all')
+            replacement: 'npm-run-all2',
+            url: resolveDocUrl({type: 'e18e', id: 'npm-run-all'})
           }
         }
       ]
@@ -194,9 +215,11 @@ await runClassic('ban-dependencies', rule, {
         {
           line: 1,
           column: 1,
-          messageId: 'noneReplacement',
+          messageId: 'removalReplacement',
           data: {
-            name: 'oogabooga'
+            name: 'oogabooga',
+            description:
+              'This module is disallowed and should be replaced with an alternative.'
           }
         }
       ]
@@ -217,7 +240,10 @@ await runClassic('ban-dependencies', rule, {
           data: {
             name: 'object-is',
             replacement: 'Object.is',
-            url: getMdnUrl('Global_Objects/Object/is')
+            url: resolveDocUrl({
+              type: 'mdn',
+              id: 'Web/JavaScript/Reference/Global_Objects/Object/is'
+            })
           }
         }
       ]
@@ -234,9 +260,11 @@ await runClassic('ban-dependencies', rule, {
         {
           line: 1,
           column: 1,
-          messageId: 'noneReplacement',
+          messageId: 'removalReplacement',
           data: {
-            name: 'oogabooga'
+            name: 'oogabooga',
+            description:
+              'This module is disallowed and should be replaced with an alternative.'
           }
         }
       ]
@@ -258,7 +286,8 @@ await runClassic('ban-dependencies', rule, {
           messageId: 'documentedReplacement',
           data: {
             name: 'npm-run-all',
-            url: getReplacementsDocUrl('npm-run-all')
+            replacement: 'npm-run-all2',
+            url: resolveDocUrl({type: 'e18e', id: 'npm-run-all'})
           }
         }
       ]
@@ -267,18 +296,7 @@ await runClassic('ban-dependencies', rule, {
 });
 
 // Test using `@eslint/json` plugin
-run({
-  name: 'ban-dependencies-json',
-  configs: [
-    {
-      files: ['**/*.json'],
-      language: 'json/json',
-      plugins: {
-        json: eslintJson
-      }
-    }
-  ],
-  rule,
+jsonRuleTester.run('ban-dependencies (JSON)', banDependencies, {
   valid: [
     {
       code: `{
@@ -320,7 +338,8 @@ run({
           messageId: 'documentedReplacement',
           data: {
             name: 'npm-run-all',
-            url: getReplacementsDocUrl('npm-run-all')
+            replacement: 'npm-run-all2',
+            url: resolveDocUrl({type: 'e18e', id: 'npm-run-all'})
           }
         }
       ]

--- a/src/rules/ban-dependencies.test.ts
+++ b/src/rules/ban-dependencies.test.ts
@@ -1,75 +1,329 @@
-import {RuleTester} from 'eslint';
-import {rules} from 'eslint-plugin-depend';
-import json from '@eslint/json';
-import * as jsoncParser from 'jsonc-eslint-parser';
+import {run, runClassic} from 'eslint-vitest-rule-tester';
+import * as tseslintParser from '@typescript-eslint/parser';
+import * as jsonParser from 'jsonc-eslint-parser';
+import eslintJson from '@eslint/json';
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    ecmaVersion: 2022,
-    sourceType: 'module'
-  }
-});
+import {rule} from '../../rules/ban-dependencies.js';
+import {getMdnUrl, getReplacementsDocUrl} from '../../util/rule-meta.js';
 
-const jsonRuleTester = new RuleTester({
-  language: 'json/json',
-  plugins: {json}
-});
-
-// TODO (jg): one day the ban-dependencies rule will live in this repo, so
-// we should move all the tests from the depend repo to here.
-
-const banDependencies = rules['ban-dependencies']!;
-
-ruleTester.run('ban-dependencies', banDependencies, {
+await runClassic('ban-dependencies', rule, {
   valid: [
-    // Allowed dependencies
-    'import {onMount} from "svelte"',
-    'import App from "./App.svelte"',
-    'const fs = require("fs")',
-
-    // Built-in modules are allowed
-    'import path from "path"',
-    'import {readFile} from "fs/promises"',
+    'const foo = 303;',
     {
-      code: `{"dependencies": {"typescript": "^5.3.2"}}`,
+      code: `import foo = require('unknown-module');`,
+      languageOptions: {
+        parser: tseslintParser
+      }
+    },
+    {
+      code: `import foo from 'unknown-module';`
+    },
+    {
+      code: `const foo = require('unknown-module');`
+    },
+    {
+      code: `
+        const moduleName = 'is-' + 'number';
+        require(moduleName);
+      `
+    },
+    {
+      code: `
+        const moduleName = 'is-' + 'number';
+        await import(moduleName);
+      `
+    },
+    {
+      code: `const foo = require('is-number');`,
+      options: [
+        {
+          presets: []
+        }
+      ]
+    },
+    {
+      code: `import foo from 'is-nan';`,
+      options: [
+        {
+          presets: ['native'],
+          allowed: ['is-nan']
+        }
+      ]
+    },
+    {
+      code: `import foo from 'oogabooga';`,
+      options: [
+        {
+          modules: ['oogabooga'],
+          allowed: ['oogabooga']
+        }
+      ]
+    },
+    {
+      code: `{
+        "dependencies": {
+          "unknown-module": "^1.0.0"
+        }
+      }`,
       filename: 'package.json',
-      languageOptions: {parser: jsoncParser}
+      languageOptions: {
+        parser: jsonParser
+      }
+    },
+    {
+      code: `{
+        "dependencies": {
+          "npm-run-all": "^1.0.0"
+        }
+      }`,
+      filename: 'not-a-package.json',
+      languageOptions: {
+        parser: jsonParser
+      }
+    },
+    {
+      code: `{
+        "not-dependencies": {
+          "some-other-nonsense": 123
+        }
+      }`,
+      filename: 'package.json',
+      languageOptions: {
+        parser: jsonParser
+      }
     }
   ],
+
   invalid: [
     {
-      code: 'import moment from "moment"',
-      errors: [{messageId: 'documentedReplacement'}]
+      code: `const foo = require('is-number');`,
+      errors: [
+        {
+          line: 1,
+          column: 13,
+          messageId: 'simpleReplacement',
+          data: {
+            name: 'is-number',
+            replacement: `Use typeof v === "number" || (typeof v === "string" && Number.isFinite(+v))`
+          }
+        }
+      ]
     },
     {
-      code: 'const moment = require("moment")',
-      errors: [{messageId: 'documentedReplacement'}]
+      code: `import foo from 'is-number';`,
+      errors: [
+        {
+          line: 1,
+          column: 1,
+          messageId: 'simpleReplacement',
+          data: {
+            name: 'is-number',
+            replacement: `Use typeof v === "number" || (typeof v === "string" && Number.isFinite(+v))`
+          }
+        }
+      ]
     },
     {
-      code: 'import _ from "lodash"',
-      errors: [{messageId: 'documentedReplacement'}]
+      code: `const foo = await import('is-number');`,
+      errors: [
+        {
+          line: 1,
+          column: 19,
+          messageId: 'simpleReplacement',
+          data: {
+            name: 'is-number',
+            replacement: `Use typeof v === "number" || (typeof v === "string" && Number.isFinite(+v))`
+          }
+        }
+      ]
     },
     {
-      code: `{"dependencies": {"moment": "^1.0.0"}}`,
+      code: `import foo = require('is-number');`,
+      languageOptions: {
+        parser: tseslintParser
+      },
+      errors: [
+        {
+          line: 1,
+          column: 1,
+          messageId: 'simpleReplacement',
+          data: {
+            name: 'is-number',
+            replacement: `Use typeof v === "number" || (typeof v === "string" && Number.isFinite(+v))`
+          }
+        }
+      ]
+    },
+    {
+      code: `import foo from 'object.entries';`,
+      errors: [
+        {
+          line: 1,
+          column: 1,
+          messageId: 'nativeReplacement',
+          data: {
+            name: 'object.entries',
+            replacement: 'Object.entries',
+            url: getMdnUrl('Global_Objects/Object/entries')
+          }
+        }
+      ]
+    },
+    {
+      code: `import foo from 'npm-run-all';`,
+      errors: [
+        {
+          line: 1,
+          column: 1,
+          messageId: 'documentedReplacement',
+          data: {
+            name: 'npm-run-all',
+            url: getReplacementsDocUrl('npm-run-all')
+          }
+        }
+      ]
+    },
+    {
+      code: `import foo from 'oogabooga';`,
+      options: [
+        {
+          modules: ['oogabooga']
+        }
+      ],
+      errors: [
+        {
+          line: 1,
+          column: 1,
+          messageId: 'noneReplacement',
+          data: {
+            name: 'oogabooga'
+          }
+        }
+      ]
+    },
+    {
+      code: `import foo from 'object-is';`,
+      options: [
+        {
+          presets: ['native'],
+          allowed: ['is-nan']
+        }
+      ],
+      errors: [
+        {
+          line: 1,
+          column: 1,
+          messageId: 'nativeReplacement',
+          data: {
+            name: 'object-is',
+            replacement: 'Object.is',
+            url: getMdnUrl('Global_Objects/Object/is')
+          }
+        }
+      ]
+    },
+    {
+      code: `import foo from 'oogabooga';`,
+      options: [
+        {
+          modules: ['oogabooga'],
+          allowed: ['foo']
+        }
+      ],
+      errors: [
+        {
+          line: 1,
+          column: 1,
+          messageId: 'noneReplacement',
+          data: {
+            name: 'oogabooga'
+          }
+        }
+      ]
+    },
+    {
+      code: `{
+        "dependencies": {
+          "npm-run-all": "^1.0.0"
+        }
+      }`,
       filename: 'package.json',
-      languageOptions: {parser: jsoncParser},
-      errors: [{messageId: 'documentedReplacement'}]
+      languageOptions: {
+        parser: jsonParser
+      },
+      errors: [
+        {
+          line: 3,
+          column: 11,
+          messageId: 'documentedReplacement',
+          data: {
+            name: 'npm-run-all',
+            url: getReplacementsDocUrl('npm-run-all')
+          }
+        }
+      ]
     }
   ]
 });
 
-jsonRuleTester.run('ban-dependencies (JSON)', banDependencies, {
+// Test using `@eslint/json` plugin
+run({
+  name: 'ban-dependencies-json',
+  configs: [
+    {
+      files: ['**/*.json'],
+      language: 'json/json',
+      plugins: {
+        json: eslintJson
+      }
+    }
+  ],
+  rule,
   valid: [
     {
-      filename: 'package.json',
-      code: `{"dependencies": {"typescript": "^5.3.2"}}`
+      code: `{
+        "dependencies": {
+          "unknown-module": "^1.0.0"
+        }
+      }`,
+      filename: 'package.json'
+    },
+    {
+      code: `{
+        "dependencies": {
+          "npm-run-all": "^1.0.0"
+        }
+      }`,
+      filename: 'not-a-package.json'
+    },
+    {
+      code: `{
+        "not-dependencies": {
+          "some-other-nonsense": 123
+        }
+      }`,
+      filename: 'package.json'
     }
   ],
   invalid: [
     {
+      code: `{
+        "dependencies": {
+          "npm-run-all": "^1.0.0"
+        }
+      }`,
       filename: 'package.json',
-      code: `{"dependencies": {"moment": "^1.0.0"}}`,
-      errors: [{messageId: 'documentedReplacement'}]
+      errors: [
+        {
+          line: 3,
+          column: 11,
+          messageId: 'documentedReplacement',
+          data: {
+            name: 'npm-run-all',
+            url: getReplacementsDocUrl('npm-run-all')
+          }
+        }
+      ]
     }
   ]
 });

--- a/src/rules/ban-dependencies.ts
+++ b/src/rules/ban-dependencies.ts
@@ -1,0 +1,356 @@
+import type {Rule} from 'eslint';
+import {
+  microUtilsReplacements,
+  preferredReplacements,
+  nativeReplacements,
+  type ModuleReplacement,
+  type ManifestModule,
+  type ModuleReplacementMapping,
+  resolveDocUrl
+} from 'module-replacements';
+import type {TSESTree} from '@typescript-eslint/typescript-estree';
+import {closestPackageSatisfiesNodeVersion} from '../utils/package-json.js';
+import type {MemberNode} from '@humanwhocodes/momoa';
+import type {AST as JsonESTree} from 'jsonc-eslint-parser';
+
+interface BanDependenciesOptions {
+  presets?: string[];
+  modules?: string[];
+  allowed?: string[];
+}
+
+const availablePresets: Record<string, ManifestModule> = {
+  microutilities: microUtilsReplacements,
+  native: nativeReplacements,
+  preferred: preferredReplacements
+};
+
+const defaultPresets = ['microutilities', 'native', 'preferred'];
+const packageJsonLikePath = /(^|[/\\])package.json$/;
+const dependencyKeys = ['dependencies', 'devDependencies'];
+
+type ImportListenerCallback = (
+  context: Rule.RuleContext,
+  node: Rule.Node,
+  source: string
+) => void;
+
+/**
+ * Creates a rule listener which listens for import/require calls and
+ * calls a callback when one is found
+ */
+export function createImportListener(
+  context: Rule.RuleContext,
+  callback: ImportListenerCallback
+): Rule.RuleListener {
+  return {
+    ImportDeclaration: (node) => {
+      if (
+        node.source.type !== 'Literal' ||
+        typeof node.source.value !== 'string'
+      ) {
+        return;
+      }
+
+      callback(context, node, node.source.value);
+    },
+    ImportExpression: (node) => {
+      if (
+        node.source.type !== 'Literal' ||
+        typeof node.source.value !== 'string'
+      ) {
+        return;
+      }
+
+      callback(context, node, node.source.value);
+    },
+    TSImportEqualsDeclaration: (astNode: Rule.Node) => {
+      const node = astNode as unknown as TSESTree.TSImportEqualsDeclaration;
+      const moduleRef = node.moduleReference;
+      if (
+        moduleRef.type !== 'TSExternalModuleReference' ||
+        moduleRef.expression.type !== 'Literal' ||
+        typeof moduleRef.expression.value !== 'string'
+      ) {
+        return;
+      }
+
+      callback(context, astNode, moduleRef.expression.value);
+    },
+    CallExpression: (node) => {
+      const [arg0] = node.arguments;
+      if (
+        arg0 === undefined ||
+        node.callee.type !== 'Identifier' ||
+        node.callee.name !== 'require' ||
+        arg0.type !== 'Literal' ||
+        typeof arg0.value !== 'string'
+      ) {
+        return;
+      }
+
+      callback(context, node, arg0.value);
+    }
+  };
+}
+
+function hasMatchingEngine(
+  replacement: ModuleReplacement,
+  context: Rule.RuleContext
+): boolean {
+  if (!replacement.engines) {
+    return true;
+  }
+
+  // TODO: support more than just Node eventually
+  const engineKey = 'nodejs';
+  const engineRange = replacement.engines.find(
+    (eng) => eng.engine === engineKey
+  )?.minVersion;
+
+  if (!engineRange) {
+    return true;
+  }
+
+  return closestPackageSatisfiesNodeVersion(context, engineRange);
+}
+
+/**
+ * Callback used for the replacement listener
+ */
+function replacementListenerCallback(
+  context: Rule.RuleContext,
+  manifests: ManifestModule[],
+  allowedNames: Set<string>,
+  node: Rule.Node,
+  source: string
+): void {
+  for (const allowedName of allowedNames) {
+    if (source === allowedName || source.startsWith(`${allowedName}/`)) {
+      return;
+    }
+  }
+
+  const replacements: ModuleReplacement[] = [];
+  let currentMapping: ModuleReplacementMapping | undefined;
+
+  for (const manifest of manifests) {
+    for (const [moduleName, mapping] of Object.entries(manifest.mappings)) {
+      if (moduleName === source || source.startsWith(`${moduleName}/`)) {
+        currentMapping = mapping;
+        for (const replacementId of mapping.replacements) {
+          const replacement = manifest.replacements[replacementId];
+          if (replacement) {
+            replacements.push(replacement);
+          }
+        }
+        break;
+      }
+    }
+  }
+
+  if (replacements.length === 0 || !currentMapping) {
+    return;
+  }
+
+  const replacement = replacements.find((rep) =>
+    hasMatchingEngine(rep, context)
+  );
+
+  if (!replacement) {
+    return;
+  }
+
+  if (replacement.type === 'native') {
+    context.report({
+      node,
+      messageId: 'nativeReplacement',
+      data: {
+        name: currentMapping.moduleName,
+        replacement: replacement.id,
+        url: resolveDocUrl(replacement.url)
+      }
+    });
+  } else if (replacement.type === 'documented') {
+    context.report({
+      node,
+      messageId: 'documentedReplacement',
+      data: {
+        name: currentMapping.moduleName,
+        replacement: replacement.replacementModule,
+        url: resolveDocUrl(replacement.url)
+      }
+    });
+  } else if (replacement.type === 'simple') {
+    context.report({
+      node,
+      messageId: 'simpleReplacement',
+      data: {
+        name: currentMapping.moduleName,
+        description: replacement.description
+      }
+    });
+  } else if (replacement.type === 'removal') {
+    context.report({
+      node,
+      messageId: 'removalReplacement',
+      data: {
+        name: currentMapping.moduleName,
+        description: replacement.description
+      }
+    });
+  }
+}
+
+/**
+ * Creates a rule listener for detecting dependencies in a `package.json`
+ * file
+ */
+export function createPackageJsonListener(
+  context: Rule.RuleContext,
+  callback: ImportListenerCallback
+): Rule.RuleListener {
+  return {
+    // Support for `@eslint/json`
+    'Document > Object > Member': (node: unknown) => {
+      const memberNode = node as MemberNode;
+      if (
+        memberNode.name.type === 'String' &&
+        dependencyKeys.includes(memberNode.name.value) &&
+        memberNode.value.type === 'Object'
+      ) {
+        for (const member of memberNode.value.members) {
+          if (member.name.type === 'String') {
+            callback(
+              context,
+              member as unknown as Rule.Node,
+              member.name.value
+            );
+          }
+        }
+      }
+    },
+    // Support for `jsonc-eslint-parser`
+    'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty': (
+      astNode: Rule.Node
+    ) => {
+      const node = astNode as unknown as JsonESTree.JSONProperty;
+
+      if (
+        node.key.type === 'JSONLiteral' &&
+        typeof node.key.value === 'string' &&
+        dependencyKeys.includes(node.key.value) &&
+        node.value.type === 'JSONObjectExpression'
+      ) {
+        for (const prop of node.value.properties) {
+          if (
+            prop.key.type === 'JSONLiteral' &&
+            typeof prop.key.value === 'string'
+          ) {
+            callback(context, prop as unknown as Rule.Node, prop.key.value);
+          }
+        }
+      }
+    }
+  };
+}
+
+export const rule: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Bans a list of dependencies from being used'
+    },
+    defaultOptions: [{}],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          presets: {
+            description: 'Preset groups of modules to ban',
+            type: 'array',
+            items: {
+              type: 'string'
+            }
+          },
+          modules: {
+            description: 'Additional module names to ban',
+            type: 'array',
+            items: {
+              type: 'string'
+            }
+          },
+          allowed: {
+            description: 'Module names to allow even if matched by a preset',
+            type: 'array',
+            items: {
+              type: 'string'
+            }
+          }
+        },
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      nativeReplacement:
+        '"{{name}}" should be replaced with native functionality. ' +
+        'You can instead use {{replacement}}. Read more here: {{url}}',
+      documentedReplacement:
+        '"{{name}}" should be replaced with an alternative package. In your ' +
+        'project, we recommend {{replacement}}. Read more here: {{url}}',
+      simpleReplacement:
+        '"{{name}}" should be replaced with inline/local logic.' +
+        '{{description}}',
+      removalReplacement:
+        '"{{name}}" is flagged as no longer needed. {{description}}'
+    }
+  },
+  create: (context) => {
+    const options = context.options[0] as BanDependenciesOptions | undefined;
+    const manifests: ManifestModule[] = [];
+    const presets = options?.presets ?? defaultPresets;
+    const modules = options?.modules;
+    const allowed = new Set(options?.allowed ?? []);
+
+    for (const preset of presets) {
+      const presetReplacements = availablePresets[preset];
+      if (presetReplacements) {
+        manifests.push(presetReplacements);
+      }
+    }
+
+    if (modules) {
+      const customManifest: ManifestModule = {
+        mappings: Object.fromEntries(
+          modules.map((mod) => [
+            mod,
+            {
+              replacements: ['__ban-dependencies__disallowed'],
+              moduleName: mod,
+              type: 'module'
+            }
+          ])
+        ),
+        replacements: {
+          '__ban-dependencies__disallowed': {
+            id: '__ban-dependencies__disallowed',
+            type: 'removal',
+            description:
+              'This module is disallowed and should be replaced with an alternative.'
+          }
+        }
+      };
+      manifests.push(customManifest);
+    }
+
+    if (packageJsonLikePath.test(context.filename)) {
+      return createPackageJsonListener(context, (context, node, name) =>
+        replacementListenerCallback(context, manifests, allowed, node, name)
+      );
+    }
+
+    return createImportListener(context, (context, node, source) =>
+      replacementListenerCallback(context, manifests, allowed, node, source)
+    );
+  }
+};

--- a/src/rules/ban-dependencies.ts
+++ b/src/rules/ban-dependencies.ts
@@ -39,7 +39,7 @@ type ImportListenerCallback = (
  * Creates a rule listener which listens for import/require calls and
  * calls a callback when one is found
  */
-export function createImportListener(
+function createImportListener(
   context: Rule.RuleContext,
   callback: ImportListenerCallback
 ): Rule.RuleListener {
@@ -206,7 +206,7 @@ function replacementListenerCallback(
  * Creates a rule listener for detecting dependencies in a `package.json`
  * file
  */
-export function createPackageJsonListener(
+function createPackageJsonListener(
   context: Rule.RuleContext,
   callback: ImportListenerCallback
 ): Rule.RuleListener {
@@ -255,7 +255,7 @@ export function createPackageJsonListener(
   };
 }
 
-export const rule: Rule.RuleModule = {
+export const banDependencies: Rule.RuleModule = {
   meta: {
     type: 'suggestion',
     docs: {

--- a/src/rules/ban-dependencies.ts
+++ b/src/rules/ban-dependencies.ts
@@ -8,10 +8,11 @@ import {
   type ModuleReplacementMapping,
   resolveDocUrl
 } from 'module-replacements';
-import type {TSESTree} from '@typescript-eslint/typescript-estree';
 import {closestPackageSatisfiesNodeVersion} from '../utils/package-json.js';
-import type {MemberNode} from '@humanwhocodes/momoa';
-import type {AST as JsonESTree} from 'jsonc-eslint-parser';
+import {
+  createImportListener,
+  createPackageJsonListener
+} from '../utils/listeners.js';
 
 interface BanDependenciesOptions {
   presets?: string[];
@@ -27,72 +28,6 @@ const availablePresets: Record<string, ManifestModule> = {
 
 const defaultPresets = ['microutilities', 'native', 'preferred'];
 const packageJsonLikePath = /(^|[/\\])package.json$/;
-const dependencyKeys = ['dependencies', 'devDependencies'];
-
-type ImportListenerCallback = (
-  context: Rule.RuleContext,
-  node: Rule.Node,
-  source: string
-) => void;
-
-/**
- * Creates a rule listener which listens for import/require calls and
- * calls a callback when one is found
- */
-function createImportListener(
-  context: Rule.RuleContext,
-  callback: ImportListenerCallback
-): Rule.RuleListener {
-  return {
-    ImportDeclaration: (node) => {
-      if (
-        node.source.type !== 'Literal' ||
-        typeof node.source.value !== 'string'
-      ) {
-        return;
-      }
-
-      callback(context, node, node.source.value);
-    },
-    ImportExpression: (node) => {
-      if (
-        node.source.type !== 'Literal' ||
-        typeof node.source.value !== 'string'
-      ) {
-        return;
-      }
-
-      callback(context, node, node.source.value);
-    },
-    TSImportEqualsDeclaration: (astNode: Rule.Node) => {
-      const node = astNode as unknown as TSESTree.TSImportEqualsDeclaration;
-      const moduleRef = node.moduleReference;
-      if (
-        moduleRef.type !== 'TSExternalModuleReference' ||
-        moduleRef.expression.type !== 'Literal' ||
-        typeof moduleRef.expression.value !== 'string'
-      ) {
-        return;
-      }
-
-      callback(context, astNode, moduleRef.expression.value);
-    },
-    CallExpression: (node) => {
-      const [arg0] = node.arguments;
-      if (
-        arg0 === undefined ||
-        node.callee.type !== 'Identifier' ||
-        node.callee.name !== 'require' ||
-        arg0.type !== 'Literal' ||
-        typeof arg0.value !== 'string'
-      ) {
-        return;
-      }
-
-      callback(context, node, arg0.value);
-    }
-  };
-}
 
 function hasMatchingEngine(
   replacement: ModuleReplacement,
@@ -200,59 +135,6 @@ function replacementListenerCallback(
       }
     });
   }
-}
-
-/**
- * Creates a rule listener for detecting dependencies in a `package.json`
- * file
- */
-function createPackageJsonListener(
-  context: Rule.RuleContext,
-  callback: ImportListenerCallback
-): Rule.RuleListener {
-  return {
-    // Support for `@eslint/json`
-    'Document > Object > Member': (node: unknown) => {
-      const memberNode = node as MemberNode;
-      if (
-        memberNode.name.type === 'String' &&
-        dependencyKeys.includes(memberNode.name.value) &&
-        memberNode.value.type === 'Object'
-      ) {
-        for (const member of memberNode.value.members) {
-          if (member.name.type === 'String') {
-            callback(
-              context,
-              member as unknown as Rule.Node,
-              member.name.value
-            );
-          }
-        }
-      }
-    },
-    // Support for `jsonc-eslint-parser`
-    'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty': (
-      astNode: Rule.Node
-    ) => {
-      const node = astNode as unknown as JsonESTree.JSONProperty;
-
-      if (
-        node.key.type === 'JSONLiteral' &&
-        typeof node.key.value === 'string' &&
-        dependencyKeys.includes(node.key.value) &&
-        node.value.type === 'JSONObjectExpression'
-      ) {
-        for (const prop of node.value.properties) {
-          if (
-            prop.key.type === 'JSONLiteral' &&
-            typeof prop.key.value === 'string'
-          ) {
-            callback(context, prop as unknown as Rule.Node, prop.key.value);
-          }
-        }
-      }
-    }
-  };
 }
 
 export const banDependencies: Rule.RuleModule = {

--- a/src/utils/listeners.ts
+++ b/src/utils/listeners.ts
@@ -1,0 +1,124 @@
+import type {Rule} from 'eslint';
+import type {TSESTree} from '@typescript-eslint/typescript-estree';
+import type {MemberNode} from '@humanwhocodes/momoa';
+import type {AST as JsonESTree} from 'jsonc-eslint-parser';
+
+export type ImportListenerCallback = (
+  context: Rule.RuleContext,
+  node: Rule.Node,
+  source: string
+) => void;
+
+const dependencyKeys = ['dependencies', 'devDependencies'];
+
+/**
+ * Creates a rule listener which listens for import/require calls and
+ * calls a callback when one is found
+ */
+export function createImportListener(
+  context: Rule.RuleContext,
+  callback: ImportListenerCallback
+): Rule.RuleListener {
+  return {
+    ImportDeclaration: (node) => {
+      if (
+        node.source.type !== 'Literal' ||
+        typeof node.source.value !== 'string'
+      ) {
+        return;
+      }
+
+      callback(context, node, node.source.value);
+    },
+    ImportExpression: (node) => {
+      if (
+        node.source.type !== 'Literal' ||
+        typeof node.source.value !== 'string'
+      ) {
+        return;
+      }
+
+      callback(context, node, node.source.value);
+    },
+    TSImportEqualsDeclaration: (astNode: Rule.Node) => {
+      const node = astNode as unknown as TSESTree.TSImportEqualsDeclaration;
+      const moduleRef = node.moduleReference;
+      if (
+        moduleRef.type !== 'TSExternalModuleReference' ||
+        moduleRef.expression.type !== 'Literal' ||
+        typeof moduleRef.expression.value !== 'string'
+      ) {
+        return;
+      }
+
+      callback(context, astNode, moduleRef.expression.value);
+    },
+    CallExpression: (node) => {
+      const [arg0] = node.arguments;
+      if (
+        arg0 === undefined ||
+        node.callee.type !== 'Identifier' ||
+        node.callee.name !== 'require' ||
+        arg0.type !== 'Literal' ||
+        typeof arg0.value !== 'string'
+      ) {
+        return;
+      }
+
+      callback(context, node, arg0.value);
+    }
+  };
+}
+
+/**
+ * Creates a rule listener for detecting dependencies in a `package.json`
+ * file
+ */
+export function createPackageJsonListener(
+  context: Rule.RuleContext,
+  callback: ImportListenerCallback
+): Rule.RuleListener {
+  return {
+    // Support for `@eslint/json`
+    'Document > Object > Member': (node: unknown) => {
+      const memberNode = node as MemberNode;
+      if (
+        memberNode.name.type === 'String' &&
+        dependencyKeys.includes(memberNode.name.value) &&
+        memberNode.value.type === 'Object'
+      ) {
+        for (const member of memberNode.value.members) {
+          if (member.name.type === 'String') {
+            callback(
+              context,
+              member as unknown as Rule.Node,
+              member.name.value
+            );
+          }
+        }
+      }
+    },
+    // Support for `jsonc-eslint-parser`
+    'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty': (
+      astNode: Rule.Node
+    ) => {
+      const node = astNode as unknown as JsonESTree.JSONProperty;
+
+      if (
+        node.key.type === 'JSONLiteral' &&
+        typeof node.key.value === 'string' &&
+        dependencyKeys.includes(node.key.value) &&
+        node.value.type === 'JSONObjectExpression'
+      ) {
+        for (const prop of node.value.properties) {
+          if (
+            prop.key.type === 'JSONLiteral' &&
+            typeof prop.key.value === 'string'
+          ) {
+            callback(context, prop as unknown as Rule.Node, prop.key.value);
+          }
+        }
+      }
+    }
+  };
+}

--- a/src/utils/package-json.test.ts
+++ b/src/utils/package-json.test.ts
@@ -1,0 +1,115 @@
+import {describe, expect, test} from 'vitest';
+import {readFile} from 'node:fs/promises';
+import * as path from 'node:path';
+import type {Rule} from 'eslint';
+import {
+  getNodeConstraint,
+  getClosestPackage,
+  closestPackageSatisfiesNodeVersion
+} from '../../util/package-json.js';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe('getNodeConstraint', () => {
+  test('null when no engines object', () => {
+    expect(getNodeConstraint({})).toBeNull();
+  });
+
+  test('null if engines is null', () => {
+    expect(getNodeConstraint({engines: null})).toBeNull();
+  });
+
+  test('null if node version non-string', () => {
+    expect(
+      getNodeConstraint({
+        engines: {
+          node: 808
+        }
+      })
+    ).toBeNull();
+  });
+
+  test('returns node version', () => {
+    expect(
+      getNodeConstraint({
+        engines: {
+          node: '1.2.3'
+        }
+      })
+    ).toBe('1.2.3');
+  });
+});
+
+describe('getClosestPackage', () => {
+  test('gets closest package.json', async () => {
+    const cwd = path.join(__dirname, '../../../test/fixtures/simple-package');
+    const packageJson = JSON.parse(
+      await readFile(path.join(cwd, 'package.json'), 'utf8')
+    );
+    const filename = path.join(cwd, 'foo.js');
+    const context = {
+      cwd,
+      filename
+    } as Rule.RuleContext;
+
+    expect(getClosestPackage(context)).toStrictEqual(packageJson);
+  });
+});
+
+describe('closestPackageSatisfiesNodeVersion', () => {
+  test('true if package has matching version', () => {
+    const cwd = path.join(__dirname, '../../../test/fixtures/simple-package');
+    const filename = path.join(cwd, 'foo.js');
+    const context = {
+      cwd,
+      filename
+    } as Rule.RuleContext;
+
+    expect(closestPackageSatisfiesNodeVersion(context, '10.9.8')).toBe(true);
+  });
+
+  test('true if package has range above version', () => {
+    const cwd = path.join(__dirname, '../../../test/fixtures/simple-package');
+    const filename = path.join(cwd, 'foo.js');
+    const context = {
+      cwd,
+      filename
+    } as Rule.RuleContext;
+
+    expect(closestPackageSatisfiesNodeVersion(context, '1.2.3')).toBe(true);
+  });
+
+  test('false if package has no matching version', () => {
+    const cwd = path.join(__dirname, '../../../test/fixtures/simple-package');
+    const filename = path.join(cwd, 'foo.js');
+    const context = {
+      cwd,
+      filename
+    } as Rule.RuleContext;
+
+    expect(closestPackageSatisfiesNodeVersion(context, '11.10.9')).toBe(false);
+  });
+
+  test('true if no package found', () => {
+    const cwd = '/';
+    const filename = path.join(cwd, 'foo.js');
+    const context = {
+      cwd,
+      filename
+    } as Rule.RuleContext;
+
+    expect(closestPackageSatisfiesNodeVersion(context, '10.9.8')).toBe(true);
+  });
+
+  test('true if no node constraint', () => {
+    const cwd = path.join(__dirname, '../../../test/fixtures/no-engines');
+    const filename = path.join(cwd, 'foo.js');
+    const context = {
+      cwd,
+      filename
+    } as Rule.RuleContext;
+
+    expect(closestPackageSatisfiesNodeVersion(context, '10.9.8')).toBe(true);
+  });
+});

--- a/src/utils/package-json.test.ts
+++ b/src/utils/package-json.test.ts
@@ -6,7 +6,7 @@ import {
   getNodeConstraint,
   getClosestPackage,
   closestPackageSatisfiesNodeVersion
-} from '../../util/package-json.js';
+} from './package-json.js';
 import {fileURLToPath} from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -43,7 +43,7 @@ describe('getNodeConstraint', () => {
 
 describe('getClosestPackage', () => {
   test('gets closest package.json', async () => {
-    const cwd = path.join(__dirname, '../../../test/fixtures/simple-package');
+    const cwd = path.join(__dirname, '../../test/fixtures/simple-package');
     const packageJson = JSON.parse(
       await readFile(path.join(cwd, 'package.json'), 'utf8')
     );
@@ -59,7 +59,7 @@ describe('getClosestPackage', () => {
 
 describe('closestPackageSatisfiesNodeVersion', () => {
   test('true if package has matching version', () => {
-    const cwd = path.join(__dirname, '../../../test/fixtures/simple-package');
+    const cwd = path.join(__dirname, '../../test/fixtures/simple-package');
     const filename = path.join(cwd, 'foo.js');
     const context = {
       cwd,
@@ -70,7 +70,7 @@ describe('closestPackageSatisfiesNodeVersion', () => {
   });
 
   test('true if package has range above version', () => {
-    const cwd = path.join(__dirname, '../../../test/fixtures/simple-package');
+    const cwd = path.join(__dirname, '../../test/fixtures/simple-package');
     const filename = path.join(cwd, 'foo.js');
     const context = {
       cwd,
@@ -81,7 +81,7 @@ describe('closestPackageSatisfiesNodeVersion', () => {
   });
 
   test('false if package has no matching version', () => {
-    const cwd = path.join(__dirname, '../../../test/fixtures/simple-package');
+    const cwd = path.join(__dirname, '../../test/fixtures/simple-package');
     const filename = path.join(cwd, 'foo.js');
     const context = {
       cwd,
@@ -103,7 +103,7 @@ describe('closestPackageSatisfiesNodeVersion', () => {
   });
 
   test('true if no node constraint', () => {
-    const cwd = path.join(__dirname, '../../../test/fixtures/no-engines');
+    const cwd = path.join(__dirname, '../../test/fixtures/no-engines');
     const filename = path.join(cwd, 'foo.js');
     const context = {
       cwd,

--- a/src/utils/package-json.ts
+++ b/src/utils/package-json.ts
@@ -1,0 +1,92 @@
+import {readFileSync} from 'node:fs';
+import * as pkg from 'empathic/package';
+import type {Rule} from 'eslint';
+import semverSatisfies from 'semver/functions/satisfies.js';
+import semverLessThan from 'semver/ranges/ltr.js';
+
+/**
+ * Gets the node engine constraint from `package.json` if possible
+ * @param {Record} packageJson Package to process
+ * @return {string | null}
+ */
+export function getNodeConstraint(
+  packageJson: Record<string, unknown>
+): string | null {
+  const engines = packageJson.engines;
+
+  if (typeof engines !== 'object' || engines === null || !('node' in engines)) {
+    return null;
+  }
+
+  const nodeVersion = engines.node;
+
+  if (typeof nodeVersion !== 'string') {
+    return null;
+  }
+
+  return nodeVersion;
+}
+
+const packageCache = new WeakMap<
+  Rule.RuleContext,
+  Record<string, unknown> | null
+>();
+
+/**
+ * Gets the closest `package.json` for a context
+ * @param {Rule.RuleContext} context ESLint context
+ * @return {Record | null}
+ */
+export function getClosestPackage(
+  context: Rule.RuleContext
+): Record<string, unknown> | null {
+  const cachedPackageJson = packageCache.get(context);
+
+  if (cachedPackageJson !== undefined) {
+    return cachedPackageJson;
+  }
+
+  const packageJsonPath = pkg.up({cwd: context.cwd});
+  let packageJson: Record<string, unknown> | null = null;
+
+  if (packageJsonPath) {
+    try {
+      packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+    } catch {
+      packageJson = null;
+    }
+  }
+  packageCache.set(context, packageJson);
+  return packageJson;
+}
+
+/**
+ * Tests whether the closest `package.json` satisfies the specified
+ * node version.
+ * This will be true if the package's `engines` field has a version range
+ * which this version satisfies, or no field at all.
+ * @param {Rule.RuleContext} context ESLint context
+ * @param {string} version Version to test
+ * @return {boolean}
+ */
+export function closestPackageSatisfiesNodeVersion(
+  context: Rule.RuleContext,
+  version: string
+): boolean {
+  const packageJson = getClosestPackage(context);
+
+  if (!packageJson) {
+    return true;
+  }
+
+  const nodeConstraint = getNodeConstraint(packageJson);
+
+  if (!nodeConstraint) {
+    return true;
+  }
+
+  return (
+    semverLessThan(version, nodeConstraint) ||
+    semverSatisfies(version, nodeConstraint)
+  );
+}

--- a/test/fixtures/no-engines/package.json
+++ b/test/fixtures/no-engines/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "no-engines",
+  "private": true,
+  "version": "0.0.1",
+  "main": "lib/main.js"
+}

--- a/test/fixtures/simple-package/package.json
+++ b/test/fixtures/simple-package/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "simple-package",
+  "private": true,
+  "version": "0.0.1",
+  "main": "lib/main.js",
+  "engines": {
+    "node": "=10.9.8"
+  }
+}


### PR DESCRIPTION
This moves the eslint-plugin-depend rule into the e18e plugin so we can deprecated the former at some point.

