### PR TITLE
feat(prefer-spread-syntax): spread syntactically known arrays in untyped contexts

### DIFF
--- a/src/rules/prefer-spread-syntax.test.ts
+++ b/src/rules/prefer-spread-syntax.test.ts
@@ -125,6 +125,27 @@ ruleTester.run('prefer-spread-syntax (untyped)', preferSpreadSyntax as never, {
       ]
     },
 
+    // Array concat with .map() arg
+    {
+      code: 'const result = arr.concat(items.map(x => x));',
+      output: 'const result = [...arr, ...items.map(x => x)];',
+      errors: [{messageId: 'preferSpreadArray'}]
+    },
+
+    // Array concat with Array.from() arg
+    {
+      code: 'const result = arr.concat(Array.from(s, n => n));',
+      output: 'const result = [...arr, ...Array.from(s, n => n)];',
+      errors: [{messageId: 'preferSpreadArray'}]
+    },
+
+    // Array concat with Object.keys() arg
+    {
+      code: 'const result = arr.concat(Object.keys(obj));',
+      output: 'const result = [...arr, ...Object.keys(obj)];',
+      errors: [{messageId: 'preferSpreadArray'}]
+    },
+
     // Array concat chained expression
     {
       code: 'const result = [1, 2].concat([3, 4]);',

--- a/src/rules/prefer-spread-syntax.ts
+++ b/src/rules/prefer-spread-syntax.ts
@@ -1,5 +1,6 @@
 import type {TSESLint, TSESTree} from '@typescript-eslint/utils';
 import {isArrayType} from '../utils/typescript.js';
+import {isSyntacticallyKnownArray} from '../utils/ast.js';
 
 type MessageIds =
   | 'preferSpreadArray'
@@ -86,10 +87,16 @@ export const preferSpreadSyntax: TSESLint.RuleModule<MessageIds, []> = {
                   parts.push(sourceCode.getText(el));
                 }
               }
-            } else if (isArrayType(arg, context) === true) {
-              parts.push(`...${sourceCode.getText(arg)}`);
             } else {
-              parts.push(sourceCode.getText(arg));
+              const typed = isArrayType(arg, context);
+              if (
+                typed === true ||
+                (typed === undefined && isSyntacticallyKnownArray(arg))
+              ) {
+                parts.push(`...${sourceCode.getText(arg)}`);
+              } else {
+                parts.push(sourceCode.getText(arg));
+              }
             }
           }
 

--- a/src/utils/ast.ts
+++ b/src/utils/ast.ts
@@ -6,6 +6,59 @@ export type AnyNode = Node | TSESTree.Node;
 
 type NodeWithParent = (Node & Rule.NodeParentExtension) | TSESTree.Node;
 
+const arrayReturningMethods = new Set([
+  'concat',
+  'copyWithin',
+  'fill',
+  'filter',
+  'flat',
+  'flatMap',
+  'map',
+  'reverse',
+  'slice',
+  'sort',
+  'splice',
+  'split',
+  'toReversed',
+  'toSorted',
+  'toSpliced',
+  'with'
+]);
+
+/**
+ * Checks if an expression is syntactically known to produce an array.
+ * e.g. array literals, Array.from/of, Object.keys/values/entries, and
+ * calls to array-returning methods.
+ */
+export function isSyntacticallyKnownArray(node: AnyNode): boolean {
+  if (node.type === 'ArrayExpression') return true;
+  if (node.type !== 'CallExpression') return false;
+  const callee = node.callee;
+  if (
+    callee.type !== 'MemberExpression' ||
+    callee.property.type !== 'Identifier'
+  ) {
+    return false;
+  }
+  if (
+    callee.object.type === 'Identifier' &&
+    callee.object.name === 'Array' &&
+    (callee.property.name === 'from' || callee.property.name === 'of')
+  ) {
+    return true;
+  }
+  if (
+    callee.object.type === 'Identifier' &&
+    callee.object.name === 'Object' &&
+    (callee.property.name === 'keys' ||
+      callee.property.name === 'values' ||
+      callee.property.name === 'entries')
+  ) {
+    return true;
+  }
+  return arrayReturningMethods.has(callee.property.name);
+}
+
 /**
  * Checks if a node is in a boolean context (where the result is only used as truthy/falsy).
  * e.g. if conditions, while loops, ternary tests, logical operators


### PR DESCRIPTION
## Summary

When type info is unavailable, the rule defaults `concat` args to "non-array" (element). That's the right call for bare identifiers, but it produces wrong autofix output for shapes whose array-ness is provable from syntax alone — e.g. `arr.concat(items.map(f))` was autofixed to `[...arr, items.map(f)]`, wrapping the array as a single element.

This adds a syntactic best-effort layer on top of the typed check. When `isArrayType` returns `undefined`, spread the arg if it's syntactically known to produce an array:

- array literals
- `Array.from(...)`, `Array.of(...)`
- `Object.keys/values/entries(...)`
- calls to array-returning instance methods (`map`, `filter`, `flat`, `flatMap`, `slice`, `concat`, `splice`, `reverse`, `sort`, `toReversed`, `toSorted`, `toSpliced`, `with`, `split`, `fill`, `copyWithin`)

Bare identifiers still default to element. The typed path is unchanged.

## Test plan

- [x] `npm test` — 650/650 pass
- [x] New cases pinned: `arr.concat(items.map(f))`, `arr.concat(Array.from(s, n => n))`, `arr.concat(Object.keys(obj))`
- [x] Existing untyped fallback (`arr.concat(other)` → `[...arr, other]`) still holds
