### PR TITLE
feat: add prefer-string-fromcharcode rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Read more at the
 | [prefer-regex-test](./src/rules/prefer-regex-test.ts) | Prefer `RegExp.test()` over `String.match()` and `RegExp.exec()` when only checking for match existence | ✅ | ✅ | 🔶 |
 | [prefer-static-regex](./src/rules/prefer-static-regex.ts) | Prefer defining regular expressions at module scope to avoid re-compilation on every function call | ✅ | ✖️ | 🔶 |
 | [prefer-inline-equality](./src/rules/prefer-inline-equality.ts) | Prefer inline equality checks over temporary object creation for simple comparisons | ✖️ | ✅ | 🔶 |
+| [prefer-string-fromcharcode](./src/rules/prefer-string-fromcharcode.ts) | Prefer `String.fromCharCode()` over `String.fromCodePoint()` for code points below `0x10000` | ✅ | ✅ | ✖️ |
 
 ## Sponsors
 

--- a/src/configs/performance-improvements.ts
+++ b/src/configs/performance-improvements.ts
@@ -12,6 +12,7 @@ export const performanceImprovements = (
     'e18e/prefer-date-now': 'error',
     'e18e/prefer-regex-test': 'error',
     'e18e/prefer-array-some': 'error',
-    'e18e/prefer-static-regex': 'error'
+    'e18e/prefer-static-regex': 'error',
+    'e18e/prefer-string-fromcharcode': 'error'
   }
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,7 +52,7 @@ const plugin: ESLint.Plugin = {
     'prefer-static-regex': preferStaticRegex,
     'prefer-inline-equality': preferInlineEquality as never as Rule.RuleModule,
     'prefer-string-fromcharcode': preferStringFromCharCode,
-    'ban-dependencies': banDependencies,
+    'ban-dependencies': banDependencies
   }
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ import {preferArraySome} from './rules/prefer-array-some.js';
 import {preferStaticRegex} from './rules/prefer-static-regex.js';
 import {preferInlineEquality} from './rules/prefer-inline-equality.js';
 import {banDependencies} from './rules/ban-dependencies.js';
+import {preferStringFromCharCode} from './rules/prefer-string-fromcharcode.js';
 
 const plugin: ESLint.Plugin = {
   meta: {
@@ -50,7 +51,8 @@ const plugin: ESLint.Plugin = {
     'prefer-array-some': preferArraySome,
     'prefer-static-regex': preferStaticRegex,
     'prefer-inline-equality': preferInlineEquality as never as Rule.RuleModule,
-    'ban-dependencies': banDependencies
+    'prefer-string-fromcharcode': preferStringFromCharCode,
+    'ban-dependencies': banDependencies,
   }
 };
 

--- a/src/rules/prefer-string-fromcharcode.test.ts
+++ b/src/rules/prefer-string-fromcharcode.test.ts
@@ -1,0 +1,75 @@
+import {RuleTester} from 'eslint';
+import {preferStringFromCharCode} from './prefer-string-fromcharcode.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('prefer-string-fromcharcode', preferStringFromCharCode, {
+  valid: [
+    // already using fromCharCode
+    'String.fromCharCode(65);',
+    'String.fromCharCode(72, 105);',
+
+    // outside fromCharCode range
+    'String.fromCodePoint(0x10000);',
+    'String.fromCodePoint(0x1F600);',
+    'String.fromCodePoint(65, 0x1F600);',
+
+    // non-literal arg
+    'String.fromCodePoint(n);',
+    'String.fromCodePoint(getCode());',
+    'String.fromCodePoint(65, code);',
+
+    // no args
+    'String.fromCodePoint();',
+
+    // spread
+    'String.fromCodePoint(...codes);',
+
+    // negative or non-integer
+    'String.fromCodePoint(-1);',
+    'String.fromCodePoint(1.5);',
+
+    // not the global String
+    'fromCodePoint(65);',
+    'foo.fromCodePoint(65);',
+    'String["fromCodePoint"](65);'
+  ],
+
+  invalid: [
+    // single literal
+    {
+      code: 'String.fromCodePoint(65);',
+      output: 'String.fromCharCode(65);',
+      errors: [{messageId: 'preferFromCharCode'}]
+    },
+    // ASCII null
+    {
+      code: 'String.fromCodePoint(0);',
+      output: 'String.fromCharCode(0);',
+      errors: [{messageId: 'preferFromCharCode'}]
+    },
+    // upper boundary
+    {
+      code: 'String.fromCodePoint(0xFFFF);',
+      output: 'String.fromCharCode(0xFFFF);',
+      errors: [{messageId: 'preferFromCharCode'}]
+    },
+    // multiple literals
+    {
+      code: 'String.fromCodePoint(72, 105, 33);',
+      output: 'String.fromCharCode(72, 105, 33);',
+      errors: [{messageId: 'preferFromCharCode'}]
+    },
+    // expression position
+    {
+      code: 'const ch = String.fromCodePoint(97);',
+      output: 'const ch = String.fromCharCode(97);',
+      errors: [{messageId: 'preferFromCharCode'}]
+    }
+  ]
+});

--- a/src/rules/prefer-string-fromcharcode.ts
+++ b/src/rules/prefer-string-fromcharcode.ts
@@ -1,0 +1,62 @@
+import type {Rule} from 'eslint';
+import type {CallExpression, Expression, SpreadElement} from 'estree';
+
+const FROM_CHARCODE_LIMIT = 0x10000;
+
+function isFromCharCodeSafeLiteral(
+  node: Expression | SpreadElement
+): boolean {
+  return (
+    node.type === 'Literal' &&
+    typeof node.value === 'number' &&
+    Number.isInteger(node.value) &&
+    node.value >= 0 &&
+    node.value < FROM_CHARCODE_LIMIT
+  );
+}
+
+export const preferStringFromCharCode: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer String.fromCharCode() over String.fromCodePoint() for code points below 0x10000',
+      recommended: true
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      preferFromCharCode:
+        'String.fromCharCode is faster than String.fromCodePoint for code points below 0x10000.'
+    }
+  },
+  create(context) {
+    return {
+      CallExpression(node: CallExpression) {
+        if (node.callee.type !== 'MemberExpression') return;
+        if (node.callee.computed) return;
+        if (
+          node.callee.object.type !== 'Identifier' ||
+          node.callee.object.name !== 'String'
+        )
+          return;
+        if (
+          node.callee.property.type !== 'Identifier' ||
+          node.callee.property.name !== 'fromCodePoint'
+        )
+          return;
+        if (node.arguments.length === 0) return;
+        if (!node.arguments.every(isFromCharCodeSafeLiteral)) return;
+
+        const property = node.callee.property;
+        context.report({
+          node: property,
+          messageId: 'preferFromCharCode',
+          fix(fixer) {
+            return fixer.replaceText(property, 'fromCharCode');
+          }
+        });
+      }
+    };
+  }
+};

--- a/src/rules/prefer-string-fromcharcode.ts
+++ b/src/rules/prefer-string-fromcharcode.ts
@@ -3,9 +3,7 @@ import type {CallExpression, Expression, SpreadElement} from 'estree';
 
 const FROM_CHARCODE_LIMIT = 0x10000;
 
-function isFromCharCodeSafeLiteral(
-  node: Expression | SpreadElement
-): boolean {
+function isFromCharCodeSafeLiteral(node: Expression | SpreadElement): boolean {
   return (
     node.type === 'Literal' &&
     typeof node.value === 'number' &&


### PR DESCRIPTION
## Summary

Adds a `prefer-string-fromcharcode` rule.

`String.fromCodePoint(n)` validates the code point and synthesises surrogate pairs when needed. For code points below `0x10000`, `String.fromCharCode(n)` returns the same character on a faster path.

The rule autofixes only when every argument is a numeric integer literal in `[0, 0xFFFF]`. Variable args, spreads, out-of-range literals, and zero-arg calls are skipped.

## Test plan

- [x] `npm test -- prefer-string-fromcharcode` — 20/20 pass
- [x] Boundary case `0xFFFF` autofixed
- [x] `0x10000` and emoji code points kept as `fromCodePoint`
- [x] Variable args, spreads, computed access, and shadowed `String` left untouched
