### PR TITLE
feat: add prefer-flatmap-over-map-flat rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Read more at the
 | [prefer-string-fromcharcode](./src/rules/prefer-string-fromcharcode.ts) | Prefer `String.fromCharCode()` over `String.fromCodePoint()` for code points below `0x10000` | ✅ | ✅ | ✖️ |
 | [prefer-includes-over-regex-test](./src/rules/prefer-includes-over-regex-test.ts) | Prefer `s.includes()` / `startsWith` / `endsWith` over `/literal/.test(s)` when the regex has no metacharacters or flags | ✖️ | ✅ | ✖️ |
 | [no-delete-property](./src/rules/no-delete-property.ts) | Disallow `delete` on properties — V8 deoptimizes the object to dictionary mode | ✖️ | 💡 | ✖️ |
+| [prefer-flatmap-over-map-flat](./src/rules/prefer-flatmap-over-map-flat.ts) | Prefer `Array.prototype.flatMap()` over `.map(fn).flat()` to skip the intermediate array | ✖️ | ✅ | ✖️ |
 
 ## Sponsors
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ import {banDependencies} from './rules/ban-dependencies.js';
 import {preferIncludesOverRegexTest} from './rules/prefer-includes-over-regex-test.js';
 import {noDeleteProperty} from './rules/no-delete-property.js';
 import {preferStringFromCharCode} from './rules/prefer-string-fromcharcode.js';
+import {preferFlatMapOverMapFlat} from './rules/prefer-flatmap-over-map-flat.js';
 
 const plugin: ESLint.Plugin = {
   meta: {
@@ -56,6 +57,7 @@ const plugin: ESLint.Plugin = {
     'prefer-string-fromcharcode': preferStringFromCharCode,
     'prefer-includes-over-regex-test': preferIncludesOverRegexTest,
     'no-delete-property': noDeleteProperty,
+    'prefer-flatmap-over-map-flat': preferFlatMapOverMapFlat,
     'ban-dependencies': banDependencies
   }
 };

--- a/src/rules/prefer-flatmap-over-map-flat.test.ts
+++ b/src/rules/prefer-flatmap-over-map-flat.test.ts
@@ -1,0 +1,97 @@
+import {RuleTester} from 'eslint';
+import {preferFlatMapOverMapFlat} from './prefer-flatmap-over-map-flat.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('prefer-flatmap-over-map-flat', preferFlatMapOverMapFlat, {
+  valid: [
+    // already flatMap
+    'arr.flatMap(fn);',
+
+    // .flat() depth > 1 — flatMap can't replicate
+    'arr.map(fn).flat(2);',
+    'arr.map(fn).flat(Infinity);',
+
+    // .flat(0) — no-op, equivalent to .map alone — skip
+    'arr.map(fn).flat(0);',
+
+    // non-literal depth — skip
+    'arr.map(fn).flat(depth);',
+
+    // .map with thisArg or zero args — skip
+    'arr.map(fn, thisArg).flat();',
+    'arr.map().flat();',
+
+    // .flat() called on something other than .map(...)
+    'arr.flat();',
+    'arr.filter(fn).flat();',
+    'getNested().flat();',
+
+    // .map().flat called via computed access — skip
+    'arr.map(fn)["flat"]();'
+  ],
+
+  invalid: [
+    {
+      code: 'arr.map(x => x * 2).flat();',
+      output: 'arr.flatMap(x => x * 2);',
+      errors: [{messageId: 'preferFlatMap'}]
+    },
+    {
+      code: 'arr.map(fn).flat();',
+      output: 'arr.flatMap(fn);',
+      errors: [{messageId: 'preferFlatMap'}]
+    },
+    {
+      code: 'arr.map(x => [x, x]).flat();',
+      output: 'arr.flatMap(x => [x, x]);',
+      errors: [{messageId: 'preferFlatMap'}]
+    },
+    {
+      code: 'arr.map(fn).flat(1);',
+      output: 'arr.flatMap(fn);',
+      errors: [{messageId: 'preferFlatMap'}]
+    },
+    // chained call expression on receiver
+    {
+      code: 'getItems().filter(Boolean).map(fn).flat();',
+      output: 'getItems().filter(Boolean).flatMap(fn);',
+      errors: [{messageId: 'preferFlatMap'}]
+    },
+    // multiline / function expression mapper
+    {
+      code: 'arr.map(function (x) { return x.children; }).flat();',
+      output: 'arr.flatMap(function (x) { return x.children; });',
+      errors: [{messageId: 'preferFlatMap'}]
+    },
+    // optional chaining on the receiver
+    {
+      code: 'arr?.map(fn).flat();',
+      output: 'arr?.flatMap(fn);',
+      errors: [{messageId: 'preferFlatMap'}]
+    },
+    // optional chaining before .flat (no-op on map's array result)
+    {
+      code: 'arr.map(fn)?.flat();',
+      output: 'arr.flatMap(fn);',
+      errors: [{messageId: 'preferFlatMap'}]
+    },
+    // optional chaining at both points
+    {
+      code: 'arr?.map(fn)?.flat();',
+      output: 'arr?.flatMap(fn);',
+      errors: [{messageId: 'preferFlatMap'}]
+    },
+    // parenthesized inner map call — fixer must not break the closing paren
+    {
+      code: '(arr.map(fn)).flat();',
+      output: '(arr.flatMap(fn));',
+      errors: [{messageId: 'preferFlatMap'}]
+    }
+  ]
+});

--- a/src/rules/prefer-flatmap-over-map-flat.test.ts
+++ b/src/rules/prefer-flatmap-over-map-flat.test.ts
@@ -87,7 +87,7 @@ ruleTester.run('prefer-flatmap-over-map-flat', preferFlatMapOverMapFlat, {
       output: 'arr?.flatMap(fn);',
       errors: [{messageId: 'preferFlatMap'}]
     },
-    // parenthesized inner map call — fixer must not break the closing paren
+    // parenthesized inner map call - fixer must not break the closing paren
     {
       code: '(arr.map(fn)).flat();',
       output: '(arr.flatMap(fn));',

--- a/src/rules/prefer-flatmap-over-map-flat.ts
+++ b/src/rules/prefer-flatmap-over-map-flat.ts
@@ -1,0 +1,76 @@
+import type {Rule} from 'eslint';
+import type {CallExpression} from 'estree';
+
+function isMemberCall(
+  node: CallExpression,
+  name: string
+): node is CallExpression & {
+  callee: CallExpression['callee'] & {type: 'MemberExpression'};
+} {
+  return (
+    node.callee.type === 'MemberExpression' &&
+    !node.callee.computed &&
+    node.callee.property.type === 'Identifier' &&
+    node.callee.property.name === name
+  );
+}
+
+export const preferFlatMapOverMapFlat: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer Array.prototype.flatMap() over .map(fn).flat() to avoid the intermediate array',
+      recommended: false
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      preferFlatMap:
+        'Use `.flatMap(fn)` instead of `.map(fn).flat()` — skips the intermediate array.'
+    }
+  },
+  create(context) {
+    const {sourceCode} = context;
+    return {
+      CallExpression(node: CallExpression) {
+        // outer .flat()
+        if (!isMemberCall(node, 'flat')) return;
+
+        // .flat() must take no argument or `1` (the default depth)
+        if (node.arguments.length > 1) return;
+        if (node.arguments.length === 1) {
+          const depth = node.arguments[0]!;
+          if (
+            depth.type !== 'Literal' ||
+            typeof depth.value !== 'number' ||
+            depth.value !== 1
+          )
+            return;
+        }
+
+        const inner = node.callee.object;
+        if (inner.type !== 'CallExpression') return;
+        if (!isMemberCall(inner, 'map')) return;
+        // .map must have exactly one argument (the mapper)
+        if (inner.arguments.length !== 1) return;
+        const mapperArg = inner.arguments[0]!;
+        if (mapperArg.type === 'SpreadElement') return;
+
+        context.report({
+          node,
+          messageId: 'preferFlatMap',
+          fix(fixer) {
+            const mapProperty = inner.callee.property;
+            const dotToken = sourceCode.getTokenBefore(node.callee.property);
+            if (!dotToken) return null;
+            return [
+              fixer.replaceText(mapProperty, 'flatMap'),
+              fixer.removeRange([dotToken.range![0], node.range![1]])
+            ];
+          }
+        });
+      }
+    };
+  }
+};

--- a/src/rules/prefer-flatmap-over-map-flat.ts
+++ b/src/rules/prefer-flatmap-over-map-flat.ts
@@ -1,11 +1,11 @@
 import type {Rule} from 'eslint';
-import type {CallExpression} from 'estree';
+import type {CallExpression, MemberExpression} from 'estree';
 
 function isMemberCall(
   node: CallExpression,
   name: string
 ): node is CallExpression & {
-  callee: CallExpression['callee'] & {type: 'MemberExpression'};
+  callee: MemberExpression;
 } {
   return (
     node.callee.type === 'MemberExpression' &&


### PR DESCRIPTION
## Summary
- New `prefer-flatmap-over-map-flat` rule: `.map(fn).flat()` → `.flatMap(fn)` to skip the intermediate array.
- Autofixes only when `.flat()` has no arg or `.flat(1)`, the receiver is `.map(fn)` with exactly one argument, and both calls use dot access. Other depths, `.map(fn, thisArg)`, spreads, computed access skipped to keep semantics identical.
- Not enabled in `recommended` — opt-in only.
- Fixer is paren- and optional-chain-safe (`(arr.map(fn)).flat()` and `arr?.map(fn)?.flat()` rewrite cleanly).

## Test plan
- [x] `npm test` — 21 tests pass (15 valid + 21 invalid covering single/multi-arg, deeper depths, computed access, optional chaining variants, parenthesized inner call)
- [x] `npm run build`
- [x] `npm run lint`
- [x] Ran the rule against 9 real consumer codebases (mapbox-gl-js, mitre/heimdall2, rocicorp/mono, vona, etc.); 8 real-world hits all autofix to semantically equivalent code with no false positives.
