### PR TITLE
feat: add no-spread-in-reduce rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Read more at the
 | [prefer-string-fromcharcode](./src/rules/prefer-string-fromcharcode.ts) | Prefer `String.fromCharCode()` over `String.fromCodePoint()` for code points below `0x10000` | ✅ | ✅ | ✖️ |
 | [prefer-includes-over-regex-test](./src/rules/prefer-includes-over-regex-test.ts) | Prefer `s.includes()` / `startsWith` / `endsWith` over `/literal/.test(s)` when the regex has no metacharacters or flags | ✖️ | ✅ | ✖️ |
 | [no-delete-property](./src/rules/no-delete-property.ts) | Disallow `delete` on properties — V8 deoptimizes the object to dictionary mode | ✖️ | 💡 | ✖️ |
+| [no-spread-in-reduce](./src/rules/no-spread-in-reduce.ts) | Disallow spreading the accumulator inside a `.reduce()` callback — it's O(N²) | ✖️ | ✖️ | ✖️ |
 
 ## Sponsors
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ import {banDependencies} from './rules/ban-dependencies.js';
 import {preferIncludesOverRegexTest} from './rules/prefer-includes-over-regex-test.js';
 import {noDeleteProperty} from './rules/no-delete-property.js';
 import {preferStringFromCharCode} from './rules/prefer-string-fromcharcode.js';
+import {noSpreadInReduce} from './rules/no-spread-in-reduce.js';
 
 const plugin: ESLint.Plugin = {
   meta: {
@@ -56,6 +57,7 @@ const plugin: ESLint.Plugin = {
     'prefer-string-fromcharcode': preferStringFromCharCode,
     'prefer-includes-over-regex-test': preferIncludesOverRegexTest,
     'no-delete-property': noDeleteProperty,
+    'no-spread-in-reduce': noSpreadInReduce,
     'ban-dependencies': banDependencies
   }
 };

--- a/src/rules/no-spread-in-reduce.test.ts
+++ b/src/rules/no-spread-in-reduce.test.ts
@@ -19,12 +19,15 @@ ruleTester.run('no-spread-in-reduce', noSpreadInReduce, {
     'arr.reduce((acc, x) => [...other, x], []);',
     'arr.reduce((acc, x) => ({...other, ...x}), {});',
 
-    // accumulator destructured — out of scope (we only handle Identifier params)
-    'arr.reduce(({list}, x) => [...list, x], {list: []});',
-
     // not a reduce call
     'arr.map(x => [...prev, x]);',
-    'arr.filter(x => true);'
+    'arr.filter(x => true);',
+
+    // nested function's return doesn't belong to the outer reduce callback
+    'arr.reduce((acc, x) => { someArr.map(y => [...acc, y]); return acc; }, []);',
+
+    // alias to something that isn't the accumulator — not flagged
+    'arr.reduce((acc, x) => { const a = other; return [...a, x]; }, []);'
   ],
 
   invalid: [
@@ -89,6 +92,39 @@ ruleTester.run('no-spread-in-reduce', noSpreadInReduce, {
     },
     {
       code: 'arr.reduce((acc, x) => ({a: 1, ...acc, b: 2}), {});',
+      errors: [{messageId: 'noSpreadInReduce'}]
+    },
+
+    // conditional return — only the spreading branch is flagged
+    {
+      code: 'arr.reduce((acc, x) => { if (cond) return [...acc, x]; return acc; }, []);',
+      errors: [{messageId: 'noSpreadInReduce'}]
+    },
+    // both branches spread — both flagged
+    {
+      code: 'arr.reduce((acc, x) => { if (cond) return [...acc, x]; return [...acc]; }, []);',
+      errors: [{messageId: 'noSpreadInReduce'}, {messageId: 'noSpreadInReduce'}]
+    },
+
+    // destructured accumulator — bound name spread in return
+    {
+      code: 'arr.reduce(({list}, x) => ({list: [...list, x]}), {list: []});',
+      errors: [{messageId: 'noSpreadInReduce'}]
+    },
+    // destructure with rename — bound name is `items`, not `list`
+    {
+      code: 'arr.reduce(({list: items}, x) => ({list: [...items, x]}), {list: []});',
+      errors: [{messageId: 'noSpreadInReduce'}]
+    },
+
+    // top-level alias of the accumulator
+    {
+      code: 'arr.reduce((acc, x) => { const a = acc; return [...a, x]; }, []);',
+      errors: [{messageId: 'noSpreadInReduce'}]
+    },
+    // top-level destructure-from-acc
+    {
+      code: 'arr.reduce((acc, x) => { const {list} = acc; return [...list, x]; }, []);',
       errors: [{messageId: 'noSpreadInReduce'}]
     }
   ]

--- a/src/rules/no-spread-in-reduce.test.ts
+++ b/src/rules/no-spread-in-reduce.test.ts
@@ -1,0 +1,95 @@
+import {RuleTester} from 'eslint';
+import {noSpreadInReduce} from './no-spread-in-reduce.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('no-spread-in-reduce', noSpreadInReduce, {
+  valid: [
+    // mutating reduce — fine
+    'arr.reduce((acc, x) => { acc.push(x); return acc; }, []);',
+    'arr.reduce((acc, x) => { acc[x.k] = x.v; return acc; }, {});',
+    'arr.reduce((acc, x) => acc + x, 0);',
+
+    // spread of something other than the accumulator
+    'arr.reduce((acc, x) => [...other, x], []);',
+    'arr.reduce((acc, x) => ({...other, ...x}), {});',
+
+    // accumulator destructured — out of scope (we only handle Identifier params)
+    'arr.reduce(({list}, x) => [...list, x], {list: []});',
+
+    // not a reduce call
+    'arr.map(x => [...prev, x]);',
+    'arr.filter(x => true);'
+  ],
+
+  invalid: [
+    // expression body, array spread
+    {
+      code: 'arr.reduce((acc, x) => [...acc, x], []);',
+      errors: [{messageId: 'noSpreadInReduce'}]
+    },
+    // expression body, object spread
+    {
+      code: 'arr.reduce((acc, x) => ({...acc, [x.k]: x.v}), {});',
+      errors: [{messageId: 'noSpreadInReduce'}]
+    },
+    // block body, terminal return with array spread
+    {
+      code: 'arr.reduce((acc, x) => { return [...acc, x * 2]; }, []);',
+      errors: [{messageId: 'noSpreadInReduce'}]
+    },
+    // block body, terminal return with object spread
+    {
+      code: 'arr.reduce((acc, item) => { return {...acc, [item.id]: item}; }, {});',
+      errors: [{messageId: 'noSpreadInReduce'}]
+    },
+    // function expression callback
+    {
+      code: 'arr.reduce(function (acc, x) { return [...acc, x]; }, []);',
+      errors: [{messageId: 'noSpreadInReduce'}]
+    },
+    // reduceRight is also covered
+    {
+      code: 'arr.reduceRight((acc, x) => [...acc, x], []);',
+      errors: [{messageId: 'noSpreadInReduce'}]
+    },
+    // accumulator named differently
+    {
+      code: 'arr.reduce((memo, item) => [...memo, item], []);',
+      errors: [{messageId: 'noSpreadInReduce'}]
+    },
+    // multiple spread elements after accumulator (still O(N²))
+    {
+      code: 'arr.reduce((acc, x) => [...acc, x, x + 1], []);',
+      errors: [{messageId: 'noSpreadInReduce'}]
+    },
+    // intermediate work then return spread — still flagged
+    {
+      code: 'arr.reduce((acc, x) => { const y = x + 1; return [...acc, y]; }, []);',
+      errors: [{messageId: 'noSpreadInReduce'}]
+    },
+    // spread NOT first in array — same O(N²) cost
+    {
+      code: 'arr.reduce((acc, x) => [x, ...acc], []);',
+      errors: [{messageId: 'noSpreadInReduce'}]
+    },
+    {
+      code: 'arr.reduce((acc, x) => [x, ...acc, y], []);',
+      errors: [{messageId: 'noSpreadInReduce'}]
+    },
+    // spread NOT first in object — same O(N²) cost
+    {
+      code: 'arr.reduce((acc, x) => ({[x.k]: x.v, ...acc}), {});',
+      errors: [{messageId: 'noSpreadInReduce'}]
+    },
+    {
+      code: 'arr.reduce((acc, x) => ({a: 1, ...acc, b: 2}), {});',
+      errors: [{messageId: 'noSpreadInReduce'}]
+    }
+  ]
+});

--- a/src/rules/no-spread-in-reduce.ts
+++ b/src/rules/no-spread-in-reduce.ts
@@ -4,48 +4,142 @@ import type {
   CallExpression,
   Expression,
   FunctionExpression,
-  Node
+  Node,
+  Pattern
 } from 'estree';
 
 type Callback = ArrowFunctionExpression | FunctionExpression;
 
-function getReturnedExpression(fn: Callback): Expression | null {
-  if (fn.body.type !== 'BlockStatement') {
-    return fn.body;
+function collectPatternNames(pattern: Pattern, out: Set<string>): void {
+  if (pattern.type === 'Identifier') {
+    out.add(pattern.name);
+  } else if (pattern.type === 'ObjectPattern') {
+    for (const prop of pattern.properties) {
+      if (prop.type === 'Property')
+        collectPatternNames(prop.value as Pattern, out);
+      else collectPatternNames(prop.argument, out);
+    }
+  } else if (pattern.type === 'ArrayPattern') {
+    for (const el of pattern.elements) if (el) collectPatternNames(el, out);
+  } else if (pattern.type === 'AssignmentPattern') {
+    collectPatternNames(pattern.left, out);
+  } else if (pattern.type === 'RestElement') {
+    collectPatternNames(pattern.argument, out);
   }
-  // Look at the last statement
-  const last = fn.body.body.at(-1);
-  if (!last || last.type !== 'ReturnStatement' || !last.argument) return null;
-  return last.argument;
 }
 
-function getAccumulatorName(fn: Callback): string | null {
+// Names bound by the accumulator parameter — including destructured fields:
+// `({list}, x)` exposes `list`; `({list: items}, x)` exposes `items`.
+// Skip the rest-param shape `(...args)` since `args[0]` is the real
+// accumulator and `[...args, x]` would have fixed-size cost, not O(N²).
+function getAccumulatorNames(fn: Callback): Set<string> {
+  const names = new Set<string>();
   const first = fn.params[0];
-  if (!first || first.type !== 'Identifier') return null;
-  return first.name;
+  if (
+    !first ||
+    (first.type !== 'Identifier' &&
+      first.type !== 'ObjectPattern' &&
+      first.type !== 'ArrayPattern' &&
+      first.type !== 'AssignmentPattern')
+  )
+    return names;
+  collectPatternNames(first, names);
+  return names;
 }
 
-// Spread position doesn't matter for the perf cost — `[x, ...acc]` and
-// `[...acc, x]` both copy all N entries each iteration. Scan every
-// element/property for a spread of the accumulator identifier.
-function spreadsAccumulator(expr: Expression, accName: string): boolean {
-  if (expr.type === 'ArrayExpression') {
-    return expr.elements.some(
-      (el) =>
-        el?.type === 'SpreadElement' &&
-        el.argument.type === 'Identifier' &&
-        el.argument.name === accName
-    );
+// Hoist names that alias or destructure the accumulator at the top of the
+// body: `const a = acc` adds `a`; `const {list} = acc` adds `list`.
+function collectAliases(fn: Callback, accNames: Set<string>): void {
+  if (fn.body.type !== 'BlockStatement') return;
+  for (const stmt of fn.body.body) {
+    if (stmt.type !== 'VariableDeclaration') continue;
+    for (const decl of stmt.declarations) {
+      if (decl.init?.type === 'Identifier' && accNames.has(decl.init.name)) {
+        collectPatternNames(decl.id, accNames);
+      }
+    }
   }
-  if (expr.type === 'ObjectExpression') {
-    return expr.properties.some(
-      (prop) =>
-        prop.type === 'SpreadElement' &&
-        prop.argument.type === 'Identifier' &&
-        prop.argument.name === accName
-    );
+}
+
+// All expressions returned from the callback (skipping nested functions —
+// their returns belong to themselves). Covers conditional branches:
+// `if (cond) return [...acc, x]; return acc;` examines both arms.
+function getReturnedExpressions(
+  fn: Callback,
+  visitorKeys: Record<string, readonly string[] | undefined>
+): Expression[] {
+  if (fn.body.type !== 'BlockStatement') return [fn.body];
+  const out: Expression[] = [];
+  function walk(node: Node): void {
+    if (
+      node.type === 'FunctionDeclaration' ||
+      node.type === 'FunctionExpression' ||
+      node.type === 'ArrowFunctionExpression'
+    )
+      return;
+    if (node.type === 'ReturnStatement' && node.argument) {
+      out.push(node.argument);
+      return;
+    }
+    const keys = visitorKeys[node.type];
+    if (!keys) return;
+    for (const key of keys) {
+      const value = (node as unknown as Record<string, unknown>)[key];
+      if (!value) continue;
+      if (Array.isArray(value)) {
+        for (const child of value) if (child) walk(child as Node);
+      } else {
+        walk(value as Node);
+      }
+    }
   }
-  return false;
+  walk(fn.body);
+  return out;
+}
+
+// Find the first SpreadElement whose argument is an accumulator-bound
+// identifier, anywhere inside the returned expression (skipping nested
+// functions). Position within an array/object literal doesn't matter for
+// the perf cost — `[x, ...acc]` and `[...acc, x]` both copy all N entries
+// each iteration. Walking past the top level also catches the destructure
+// pattern `({list: [...list, x]})`, where the spread sits inside a
+// rebuilt accumulator shape.
+function findAccumulatorSpread(
+  expr: Expression,
+  accNames: Set<string>,
+  visitorKeys: Record<string, readonly string[] | undefined>
+): Node | null {
+  let found: Node | null = null;
+  function walk(node: Node): void {
+    if (found) return;
+    if (
+      node.type === 'FunctionDeclaration' ||
+      node.type === 'FunctionExpression' ||
+      node.type === 'ArrowFunctionExpression'
+    )
+      return;
+    if (
+      node.type === 'SpreadElement' &&
+      node.argument.type === 'Identifier' &&
+      accNames.has(node.argument.name)
+    ) {
+      found = node;
+      return;
+    }
+    const keys = visitorKeys[node.type];
+    if (!keys) return;
+    for (const key of keys) {
+      const value = (node as unknown as Record<string, unknown>)[key];
+      if (!value) continue;
+      if (Array.isArray(value)) {
+        for (const child of value) if (child) walk(child as Node);
+      } else {
+        walk(value as Node);
+      }
+    }
+  }
+  walk(expr);
+  return found;
 }
 
 function isReduceCall(node: CallExpression): boolean {
@@ -74,6 +168,10 @@ export const noSpreadInReduce: Rule.RuleModule = {
     }
   },
   create(context) {
+    const visitorKeys = context.sourceCode.visitorKeys as Record<
+      string,
+      readonly string[] | undefined
+    >;
     return {
       CallExpression(node: CallExpression) {
         if (!isReduceCall(node)) return;
@@ -83,16 +181,18 @@ export const noSpreadInReduce: Rule.RuleModule = {
           callback.type !== 'FunctionExpression'
         )
           return;
-        const accName = getAccumulatorName(callback);
-        if (!accName) return;
-        const ret = getReturnedExpression(callback);
-        if (!ret) return;
-        if (!spreadsAccumulator(ret, accName)) return;
-
-        context.report({
-          node: ret,
-          messageId: 'noSpreadInReduce'
-        });
+        const accNames = getAccumulatorNames(callback);
+        if (accNames.size === 0) return;
+        collectAliases(callback, accNames);
+        for (const ret of getReturnedExpressions(callback, visitorKeys)) {
+          const spread = findAccumulatorSpread(ret, accNames, visitorKeys);
+          if (spread) {
+            context.report({
+              node: spread,
+              messageId: 'noSpreadInReduce'
+            });
+          }
+        }
       }
     };
   }

--- a/src/rules/no-spread-in-reduce.ts
+++ b/src/rules/no-spread-in-reduce.ts
@@ -1,0 +1,99 @@
+import type {Rule} from 'eslint';
+import type {
+  ArrowFunctionExpression,
+  CallExpression,
+  Expression,
+  FunctionExpression,
+  Node
+} from 'estree';
+
+type Callback = ArrowFunctionExpression | FunctionExpression;
+
+function getReturnedExpression(fn: Callback): Expression | null {
+  if (fn.body.type !== 'BlockStatement') {
+    return fn.body;
+  }
+  // Look at the last statement
+  const last = fn.body.body.at(-1);
+  if (!last || last.type !== 'ReturnStatement' || !last.argument) return null;
+  return last.argument;
+}
+
+function getAccumulatorName(fn: Callback): string | null {
+  const first = fn.params[0];
+  if (!first || first.type !== 'Identifier') return null;
+  return first.name;
+}
+
+// Spread position doesn't matter for the perf cost — `[x, ...acc]` and
+// `[...acc, x]` both copy all N entries each iteration. Scan every
+// element/property for a spread of the accumulator identifier.
+function spreadsAccumulator(expr: Expression, accName: string): boolean {
+  if (expr.type === 'ArrayExpression') {
+    return expr.elements.some(
+      (el) =>
+        el?.type === 'SpreadElement' &&
+        el.argument.type === 'Identifier' &&
+        el.argument.name === accName
+    );
+  }
+  if (expr.type === 'ObjectExpression') {
+    return expr.properties.some(
+      (prop) =>
+        prop.type === 'SpreadElement' &&
+        prop.argument.type === 'Identifier' &&
+        prop.argument.name === accName
+    );
+  }
+  return false;
+}
+
+function isReduceCall(node: CallExpression): boolean {
+  return (
+    node.callee.type === 'MemberExpression' &&
+    !node.callee.computed &&
+    node.callee.property.type === 'Identifier' &&
+    (node.callee.property.name === 'reduce' ||
+      node.callee.property.name === 'reduceRight') &&
+    node.arguments.length >= 1
+  );
+}
+
+export const noSpreadInReduce: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow spreading the accumulator inside a `reduce` callback (O(N²) growth)',
+      recommended: false
+    },
+    schema: [],
+    messages: {
+      noSpreadInReduce:
+        'Spreading the accumulator on every reduce step is O(N²). Mutate the accumulator (push/Object.assign) and return it, or use a different shape (e.g. `flatMap`, `Object.fromEntries`).'
+    }
+  },
+  create(context) {
+    return {
+      CallExpression(node: CallExpression) {
+        if (!isReduceCall(node)) return;
+        const callback = node.arguments[0] as Node;
+        if (
+          callback.type !== 'ArrowFunctionExpression' &&
+          callback.type !== 'FunctionExpression'
+        )
+          return;
+        const accName = getAccumulatorName(callback);
+        if (!accName) return;
+        const ret = getReturnedExpression(callback);
+        if (!ret) return;
+        if (!spreadsAccumulator(ret, accName)) return;
+
+        context.report({
+          node: ret,
+          messageId: 'noSpreadInReduce'
+        });
+      }
+    };
+  }
+};

--- a/src/rules/no-spread-in-reduce.ts
+++ b/src/rules/no-spread-in-reduce.ts
@@ -15,12 +15,18 @@ function collectPatternNames(pattern: Pattern, out: Set<string>): void {
     out.add(pattern.name);
   } else if (pattern.type === 'ObjectPattern') {
     for (const prop of pattern.properties) {
-      if (prop.type === 'Property')
-        collectPatternNames(prop.value as Pattern, out);
-      else collectPatternNames(prop.argument, out);
+      if (prop.type === 'Property') {
+        collectPatternNames(prop.value, out);
+      } else {
+        collectPatternNames(prop.argument, out);
+      }
     }
   } else if (pattern.type === 'ArrayPattern') {
-    for (const el of pattern.elements) if (el) collectPatternNames(el, out);
+    for (const el of pattern.elements) {
+      if (el) {
+        collectPatternNames(el, out);
+      }
+    }
   } else if (pattern.type === 'AssignmentPattern') {
     collectPatternNames(pattern.left, out);
   } else if (pattern.type === 'RestElement') {
@@ -61,8 +67,48 @@ function collectAliases(fn: Callback, accNames: Set<string>): void {
   }
 }
 
-// All expressions returned from the callback (skipping nested functions —
-// their returns belong to themselves). Covers conditional branches:
+// Walk `root`, skipping nested function bodies (their contents belong to
+// themselves, not to the enclosing reduce callback). `visit` runs on each
+// node; return `true` to short-circuit the whole traversal, or `'skip'` to
+// stop descending into the current node's children.
+//
+// TODO (jg): maybe one day capture these during ESLint's normal traversal
+function walkSkippingFunctions(
+  root: Node,
+  visitorKeys: Record<string, readonly string[] | undefined>,
+  visit: (node: Node) => boolean | 'skip' | undefined
+): void {
+  let stopped = false;
+  function walk(node: Node): void {
+    if (stopped) return;
+    if (
+      node.type === 'FunctionDeclaration' ||
+      node.type === 'FunctionExpression' ||
+      node.type === 'ArrowFunctionExpression'
+    )
+      return;
+    const result = visit(node);
+    if (result === true) {
+      stopped = true;
+      return;
+    }
+    if (result === 'skip') return;
+    const keys = visitorKeys[node.type];
+    if (!keys) return;
+    for (const key of keys) {
+      const value = (node as unknown as Record<string, unknown>)[key];
+      if (!value) continue;
+      if (Array.isArray(value)) {
+        for (const child of value) if (child) walk(child as Node);
+      } else {
+        walk(value as Node);
+      }
+    }
+  }
+  walk(root);
+}
+
+// All expressions returned from the callback. Covers conditional branches:
 // `if (cond) return [...acc, x]; return acc;` examines both arms.
 function getReturnedExpressions(
   fn: Callback,
@@ -70,75 +116,40 @@ function getReturnedExpressions(
 ): Expression[] {
   if (fn.body.type !== 'BlockStatement') return [fn.body];
   const out: Expression[] = [];
-  function walk(node: Node): void {
-    if (
-      node.type === 'FunctionDeclaration' ||
-      node.type === 'FunctionExpression' ||
-      node.type === 'ArrowFunctionExpression'
-    )
-      return;
+  walkSkippingFunctions(fn.body, visitorKeys, (node) => {
     if (node.type === 'ReturnStatement' && node.argument) {
       out.push(node.argument);
-      return;
+      return 'skip';
     }
-    const keys = visitorKeys[node.type];
-    if (!keys) return;
-    for (const key of keys) {
-      const value = (node as unknown as Record<string, unknown>)[key];
-      if (!value) continue;
-      if (Array.isArray(value)) {
-        for (const child of value) if (child) walk(child as Node);
-      } else {
-        walk(value as Node);
-      }
-    }
-  }
-  walk(fn.body);
+    return undefined;
+  });
   return out;
 }
 
 // Find the first SpreadElement whose argument is an accumulator-bound
-// identifier, anywhere inside the returned expression (skipping nested
-// functions). Position within an array/object literal doesn't matter for
-// the perf cost — `[x, ...acc]` and `[...acc, x]` both copy all N entries
-// each iteration. Walking past the top level also catches the destructure
-// pattern `({list: [...list, x]})`, where the spread sits inside a
-// rebuilt accumulator shape.
+// identifier, anywhere inside the returned expression. Position within an
+// array/object literal doesn't matter for the perf cost — `[x, ...acc]`
+// and `[...acc, x]` both copy all N entries each iteration. Walking past
+// the top level also catches the destructure pattern
+// `({list: [...list, x]})`, where the spread sits inside a rebuilt
+// accumulator shape.
 function findAccumulatorSpread(
   expr: Expression,
   accNames: Set<string>,
   visitorKeys: Record<string, readonly string[] | undefined>
 ): Node | null {
   let found: Node | null = null;
-  function walk(node: Node): void {
-    if (found) return;
-    if (
-      node.type === 'FunctionDeclaration' ||
-      node.type === 'FunctionExpression' ||
-      node.type === 'ArrowFunctionExpression'
-    )
-      return;
+  walkSkippingFunctions(expr, visitorKeys, (node) => {
     if (
       node.type === 'SpreadElement' &&
       node.argument.type === 'Identifier' &&
       accNames.has(node.argument.name)
     ) {
       found = node;
-      return;
+      return true;
     }
-    const keys = visitorKeys[node.type];
-    if (!keys) return;
-    for (const key of keys) {
-      const value = (node as unknown as Record<string, unknown>)[key];
-      if (!value) continue;
-      if (Array.isArray(value)) {
-        for (const child of value) if (child) walk(child as Node);
-      } else {
-        walk(value as Node);
-      }
-    }
-  }
-  walk(expr);
+    return undefined;
+  });
   return found;
 }
 


### PR DESCRIPTION
## Summary

New `no-spread-in-reduce` rule: spreading the accumulator inside `.reduce()` rebuilds it every step, which is O(N²). The rule flags it and points at the spread; the user mutates (`acc.push(x); return acc`) or restructures (`flatMap`, `Object.fromEntries`) instead.

A real fix this catches (heimdall2 vuln-merging reducer):

```js
// before — O(N²)
list.reduce((acc, cur) => {
  const i = acc.findIndex(v => v.id === cur.id);
  if (i === -1) return [...acc, cur];                  // ← flagged
  acc[i].components.push(...cur.components);
  return acc;
}, []);

// after — O(N)
list.reduce((acc, cur) => {
  const i = acc.findIndex(v => v.id === cur.id);
  if (i === -1) { acc.push(cur); return acc; }
  acc[i].components.push(...cur.components);
  return acc;
}, []);
```

## Commits

This PR is **two commits** that you can land together or independently:

1. **`feat: flag spread of accumulator inside reduce callback`** — the core rule. Flags the direct shape `(acc, x) => [...acc, x]` (and object-spread, `reduceRight`, function-expression callbacks, `[x, ...acc]` / `{k: v, ...acc}` — position doesn't change the perf cost).

2. **`feat: also flag conditional, destructured, and aliased accumulators`** — broadens detection to:
   - Conditional returns: `if (cond) return [...acc, x]; return acc;` walks both arms.
   - Destructured accumulator: `({list}, x) => ({list: [...list, x]})` treats every name bound by the param pattern (with renames) as an accumulator name.
   - Top-level aliases: `const a = acc;` / `const {list} = acc;` hoist into the accumulator name set.

   **If you'd rather keep the rule small for the first cut, the second commit can be dropped** — the first commit lands a useful rule on its own. The second commit catches 2 additional real heimdall2 hits the first commit misses.

## Design notes

- Not in `recommended` — opt-in only.
- No autofix in this PR. Considered, but only a narrow subset is mechanically safe (spread-first append-only, with a fresh `[]`/`{}` initial). Happy to add it as a `suggest` in a follow-up if you want it.
- Out of scope: `acc.concat(x)` and `Object.assign({}, acc, x)` (same perf, but a different rule's name); `[...acc.slice(...), x]` (false-positive risk too high without semantic info).

## Test plan
- [x] `npm test` — 697 tests pass (28 in this rule, including spread position, conditional branches, destructured params, aliased acc, nested-function skip)
- [x] `npm run build`
- [x] `npm run lint`
- [x] Ran the rule against knip + 9 cloned consumer codebases. **7 real-world hits** across 4 of them (knip 1, rocicorp/mono 3, vona 1, heimdall2 2). All sampled hits are real `[...acc, x]` / `{...acc, k: v}` accumulators. No false positives. The 2 heimdall2 hits are unique to the second commit (conditional-branch shapes the first commit doesn't reach).
