### PR TITLE
feat: add prefer-includes-over-regex-test rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Read more at the
 | [prefer-static-regex](./src/rules/prefer-static-regex.ts) | Prefer defining regular expressions at module scope to avoid re-compilation on every function call | ✅ | ✖️ | 🔶 |
 | [prefer-inline-equality](./src/rules/prefer-inline-equality.ts) | Prefer inline equality checks over temporary object creation for simple comparisons | ✖️ | ✅ | 🔶 |
 | [prefer-string-fromcharcode](./src/rules/prefer-string-fromcharcode.ts) | Prefer `String.fromCharCode()` over `String.fromCodePoint()` for code points below `0x10000` | ✅ | ✅ | ✖️ |
+| [prefer-includes-over-regex-test](./src/rules/prefer-includes-over-regex-test.ts) | Prefer `s.includes()` / `startsWith` / `endsWith` over `/literal/.test(s)` when the regex has no metacharacters or flags | ✖️ | ✅ | ✖️ |
 
 ## Sponsors
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ import {preferArraySome} from './rules/prefer-array-some.js';
 import {preferStaticRegex} from './rules/prefer-static-regex.js';
 import {preferInlineEquality} from './rules/prefer-inline-equality.js';
 import {banDependencies} from './rules/ban-dependencies.js';
+import {preferIncludesOverRegexTest} from './rules/prefer-includes-over-regex-test.js';
 import {preferStringFromCharCode} from './rules/prefer-string-fromcharcode.js';
 
 const plugin: ESLint.Plugin = {
@@ -52,6 +53,7 @@ const plugin: ESLint.Plugin = {
     'prefer-static-regex': preferStaticRegex,
     'prefer-inline-equality': preferInlineEquality as never as Rule.RuleModule,
     'prefer-string-fromcharcode': preferStringFromCharCode,
+    'prefer-includes-over-regex-test': preferIncludesOverRegexTest,
     'ban-dependencies': banDependencies
   }
 };

--- a/src/rules/prefer-includes-over-regex-test.test.ts
+++ b/src/rules/prefer-includes-over-regex-test.test.ts
@@ -1,0 +1,111 @@
+import {RuleTester} from 'eslint';
+import {preferIncludesOverRegexTest} from './prefer-includes-over-regex-test.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('prefer-includes-over-regex-test', preferIncludesOverRegexTest, {
+  valid: [
+    // already using string methods
+    "s.includes('foo');",
+    "s.startsWith('foo');",
+    "s.endsWith('foo');",
+
+    // regex with special characters
+    '/foo.bar/.test(s);',
+    '/foo+/.test(s);',
+    '/[abc]/.test(s);',
+    '/(foo|bar)/.test(s);',
+    '/\\d/.test(s);',
+    '/foo\\$/.test(s);',
+
+    // regex with flags (semantics differ)
+    '/foo/i.test(s);',
+    '/foo/g.test(s);',
+
+    // empty regex bodies
+    '/^$/.test(s);', // matches empty — could autofix to s==='' but skipped
+    '/^/.test(s);',
+    '/$/.test(s);',
+
+    // wrong receiver / method
+    'regex.test(s);',
+    "s.test('foo');",
+    '/foo/.exec(s);',
+
+    // .test() with extra args
+    '/foo/.test(s, extra);',
+
+    // RegExp constructor (not a literal)
+    "new RegExp('foo').test(s);"
+  ],
+
+  invalid: [
+    // plain — includes
+    {
+      code: 'if (/foo/.test(s)) {}',
+      output: 'if (s.includes("foo")) {}',
+      errors: [{messageId: 'preferIncludes'}]
+    },
+
+    // start anchor — startsWith
+    {
+      code: 'if (/^foo/.test(s)) {}',
+      output: 'if (s.startsWith("foo")) {}',
+      errors: [{messageId: 'preferStartsWith'}]
+    },
+
+    // end anchor — endsWith
+    {
+      code: 'if (/foo$/.test(s)) {}',
+      output: 'if (s.endsWith("foo")) {}',
+      errors: [{messageId: 'preferEndsWith'}]
+    },
+
+    // both anchors — equals
+    {
+      code: 'if (/^foo$/.test(s)) {}',
+      output: 'if (s === "foo") {}',
+      errors: [{messageId: 'preferEquals'}]
+    },
+
+    // numeric/alphanumeric pattern
+    {
+      code: '/abc123/.test(s);',
+      output: 's.includes("abc123");',
+      errors: [{messageId: 'preferIncludes'}]
+    },
+
+    // arg is a call expression — no extra parens
+    {
+      code: '/foo/.test(getStr());',
+      output: 'getStr().includes("foo");',
+      errors: [{messageId: 'preferIncludes'}]
+    },
+
+    // arg is a logical expression — needs parens
+    {
+      code: '/foo/.test(a || b);',
+      output: '(a || b).includes("foo");',
+      errors: [{messageId: 'preferIncludes'}]
+    },
+
+    // arg is a conditional — needs parens, especially for the equals case
+    {
+      code: '/^foo$/.test(x ? a : b);',
+      output: '(x ? a : b) === "foo";',
+      errors: [{messageId: 'preferEquals'}]
+    },
+
+    // double-quoted literal in pattern handled fine
+    {
+      code: '/abc/.test(s);',
+      output: 's.includes("abc");',
+      errors: [{messageId: 'preferIncludes'}]
+    }
+  ]
+});

--- a/src/rules/prefer-includes-over-regex-test.ts
+++ b/src/rules/prefer-includes-over-regex-test.ts
@@ -66,7 +66,7 @@ export const preferIncludesOverRegexTest: Rule.RuleModule = {
     schema: [],
     messages: {
       preferIncludes:
-        "Prefer `s.includes('{{literal}}')` over `/{{pattern}}/.test(s)` — skips the regex engine entirely.",
+        "Prefer `s.includes('{{literal}}')` over `/{{pattern}}/.test(s)`.",
       preferStartsWith:
         "Prefer `s.startsWith('{{literal}}')` over `/^{{literal}}/.test(s)`.",
       preferEndsWith:

--- a/src/rules/prefer-includes-over-regex-test.ts
+++ b/src/rules/prefer-includes-over-regex-test.ts
@@ -1,0 +1,137 @@
+import type {Rule} from 'eslint';
+import type {CallExpression, Expression, RegExpLiteral} from 'estree';
+
+function isRegexLiteral(node: Expression): node is RegExpLiteral {
+  return node.type === 'Literal' && 'regex' in node && node.regex !== undefined;
+}
+
+const SPECIAL_CHARS_RE = /[\\.*+?()[\]{}|^$]/;
+
+type Kind = 'includes' | 'startsWith' | 'endsWith' | 'equals';
+
+function classifyRegex(pattern: string): {kind: Kind; literal: string} | null {
+  let body = pattern;
+  let hasStart = false;
+  let hasEnd = false;
+
+  if (body.startsWith('^')) {
+    hasStart = true;
+    body = body.slice(1);
+  }
+  // A trailing `$` is the end anchor unless it's preceded by an unescaped `\`
+  if (body.endsWith('$') && !body.endsWith('\\$')) {
+    hasEnd = true;
+    body = body.slice(0, -1);
+  }
+
+  if (body.length === 0) return null;
+  if (SPECIAL_CHARS_RE.test(body)) return null;
+
+  let kind: Kind;
+  if (hasStart && hasEnd) kind = 'equals';
+  else if (hasStart) kind = 'startsWith';
+  else if (hasEnd) kind = 'endsWith';
+  else kind = 'includes';
+
+  return {kind, literal: body};
+}
+
+function needsParens(node: Expression): boolean {
+  switch (node.type) {
+    case 'Identifier':
+    case 'Literal':
+    case 'MemberExpression':
+    case 'CallExpression':
+    case 'NewExpression':
+    case 'ThisExpression':
+    case 'ArrayExpression':
+    case 'ObjectExpression':
+    case 'TemplateLiteral':
+    case 'TaggedTemplateExpression':
+      return false;
+    default:
+      return true;
+  }
+}
+
+export const preferIncludesOverRegexTest: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer String.prototype.{includes,startsWith,endsWith} over equivalent regex.test() calls',
+      recommended: false
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      preferIncludes:
+        "Prefer `s.includes('{{literal}}')` over `/{{pattern}}/.test(s)` — skips the regex engine entirely.",
+      preferStartsWith:
+        "Prefer `s.startsWith('{{literal}}')` over `/^{{literal}}/.test(s)`.",
+      preferEndsWith:
+        "Prefer `s.endsWith('{{literal}}')` over `/{{literal}}$/.test(s)`.",
+      preferEquals:
+        "Prefer `s === '{{literal}}'` over `/^{{literal}}$/.test(s)`."
+    }
+  },
+  create(context) {
+    const sourceCode = context.sourceCode;
+    return {
+      CallExpression(node: CallExpression) {
+        if (node.callee.type !== 'MemberExpression') return;
+        if (node.callee.computed) return;
+        if (
+          node.callee.property.type !== 'Identifier' ||
+          node.callee.property.name !== 'test'
+        )
+          return;
+        if (node.arguments.length !== 1) return;
+
+        const regex = node.callee.object;
+        if (regex.type !== 'Literal' || !isRegexLiteral(regex)) return;
+        if (regex.regex.flags !== '') return;
+
+        const cls = classifyRegex(regex.regex.pattern);
+        if (!cls) return;
+
+        const arg = node.arguments[0]!;
+        if (arg.type === 'SpreadElement') return;
+        const argText = needsParens(arg as Expression)
+          ? `(${sourceCode.getText(arg)})`
+          : sourceCode.getText(arg);
+        const literalText = JSON.stringify(cls.literal);
+
+        let replacement: string;
+        let messageId: string;
+        switch (cls.kind) {
+          case 'includes':
+            replacement = `${argText}.includes(${literalText})`;
+            messageId = 'preferIncludes';
+            break;
+          case 'startsWith':
+            replacement = `${argText}.startsWith(${literalText})`;
+            messageId = 'preferStartsWith';
+            break;
+          case 'endsWith':
+            replacement = `${argText}.endsWith(${literalText})`;
+            messageId = 'preferEndsWith';
+            break;
+          case 'equals':
+            replacement = `${argText} === ${literalText}`;
+            messageId = 'preferEquals';
+            break;
+        }
+
+        context.report({
+          node,
+          messageId,
+          data: {literal: cls.literal, pattern: regex.regex.pattern},
+          fix(fixer) {
+            return fixer.replaceText(node, replacement);
+          }
+        });
+      }
+    };
+  }
+};


### PR DESCRIPTION
## Summary

New `prefer-includes-over-regex-test` rule: when a `<regex>.test(s)` has no metacharacters and no flags, the regex engine work is pure overhead — `s.includes('foo')` (or `startsWith` / `endsWith` / `===`) does the same thing without compiling and tearing down a state machine.

A real fix this catches (knip `src/plugins/gatsby/index.ts`):

```ts
// before
if (/gatsby-config/.test(configFileName)) { ... }
if (/gatsby-node/.test(configFileName)) { ... }

// after
if (configFileName.includes("gatsby-config")) { ... }
if (configFileName.includes("gatsby-node")) { ... }
```

## Behaviour

Autofixes the four shapes:

| Pattern | Replacement | Message |
|---|---|---|
| `/foo/.test(s)` | `s.includes("foo")` | `preferIncludes` |
| `/^foo/.test(s)` | `s.startsWith("foo")` | `preferStartsWith` |
| `/foo$/.test(s)` | `s.endsWith("foo")` | `preferEndsWith` |
| `/^foo$/.test(s)` | `s === "foo"` | `preferEquals` |

Skips:
- patterns containing any of `\.*+?()[]{}|^$` after stripping anchors
- regex flags (`/i`, `/g`, …) since they change semantics
- empty bodies (`//`, `/^$/`, `/^/`, `/$/`)
- dynamic `new RegExp(...).test(...)` (could be anything at runtime)
- `.test()` with extra arguments

Wraps the test argument in parens when needed to preserve precedence (logical, conditional, await, TS cast, etc.).

## Caveat

`regex.test(x)` coerces `x` to string; `x.includes(…)` throws on non-strings. The rule has no way to detect non-string receivers without types, so this can produce broken code for `regex.test(maybeNumber)`. In practice almost all real `.test()` callers pass strings, but the risk is the reason this lands as opt-in (not in `recommended`).

## Test plan
- [x] `npm test` — 706 tests pass (16 in this rule)
- [x] `npm run build`
- [x] `npm run lint`
- [x] Ran the rule against knip + 9 cloned consumer codebases. **8 real source hits across 3 codebases** (knip 2, rocicorp/mono 5, mapbox-gl-js 1). Sampled 4 — all idiomatic substring tests with no metacharacters; autofix produces clean equivalents. Lower yield than some other rules because most of these codebases already use string methods directly — but the savings per call site are substantial when this pattern does appear.
