### PR TITLE
Extend the prefer-array-some rule to also detect filter().length calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /node_modules
 /lib
 /coverage
+
+# IntelliJ IDE Workspace Settings
+.idea

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Read more at the
 |------|-------------|-------------|---------|----------------|
 | [no-indexof-equality](./src/rules/no-indexof-equality.ts) | Prefer `startsWith()` for strings and direct array access over `indexOf()` equality checks | ✖️ | ✅ | ✅ |
 | [prefer-array-from-map](./src/rules/prefer-array-from-map.ts) | Prefer `Array.from(iterable, mapper)` over `[...iterable].map(mapper)` to avoid intermediate array allocation | ✅ | ✅ | ✖️ |
-| [prefer-array-some](./src/rules/prefer-array-some.ts) | Prefer `Array.some()` over `Array.find()` when checking for element existence | ✅ | ✅ | ✖️ |
+| [prefer-array-some](./src/rules/prefer-array-some.ts) | Prefer `Array.some()` over `Array.find()` and `Array.filter().length` checks when checking for element existence | ✅ | ✅ | ✖️ |
 | [prefer-timer-args](./src/rules/prefer-timer-args.ts) | Prefer passing function and arguments directly to `setTimeout`/`setInterval` instead of wrapping in an arrow function or using `bind` | ✅ | ✅ | ✖️ |
 | [prefer-date-now](./src/rules/prefer-date-now.ts) | Prefer `Date.now()` over `new Date().getTime()` and `+new Date()` | ✅ | ✅ | ✖️ |
 | [prefer-regex-test](./src/rules/prefer-regex-test.ts) | Prefer `RegExp.test()` over `String.match()` and `RegExp.exec()` when only checking for match existence | ✅ | ✅ | 🔶 |

--- a/src/rules/prefer-array-some.test.ts
+++ b/src/rules/prefer-array-some.test.ts
@@ -37,7 +37,40 @@ ruleTester.run('prefer-array-some', preferArraySome, {
     'if (arr.find(fn) == undefined) {}',
     'if (arr.find(fn) != undefined) {}',
     'if (arr.find(fn) == null) {}',
-    'if (arr.find(fn) != null) {}'
+    'if (arr.find(fn) != null) {}',
+
+    // --- filter().length cases that should NOT be flagged ---
+
+    // result used as a number, not a boolean existence check
+    'const count = arr.filter(fn).length',
+    'console.log(arr.filter(fn).length)',
+    'function foo() { return arr.filter(fn).length }',
+    'const n = arr.filter(fn).length + 1',
+    'Math.max(arr.filter(fn).length, 1)',
+
+    // quantity comparisons (not "does any exist?")
+    'if (arr.filter(fn).length > 1) {}',
+    'if (arr.filter(fn).length >= 2) {}',
+    'if (arr.filter(fn).length === 3) {}',
+    'if (arr.filter(fn).length !== 1) {}',
+    'if (arr.filter(fn).length < 3) {}',
+    'if (arr.filter(fn).length <= 2) {}',
+    'if (2 > arr.filter(fn).length) {}',
+    'if (3 === arr.filter(fn).length) {}',
+
+    // filter() with no arguments — .some() would throw a TypeError
+    'if (arr.filter().length > 0) {}',
+    'if (arr.filter().length) {}',
+
+    // always-true / always-false logic bugs — don't suggest some(), these are broken
+    'if (arr.filter(fn).length >= 0) {}',
+    'if (arr.filter(fn).length > -1) {}',
+    'if (arr.filter(fn).length < 0) {}',
+    'if (0 > arr.filter(fn).length) {}',
+
+    // loose equality — only strict === / !== are flagged
+    'if (arr.filter(fn).length == 0) {}',
+    'if (arr.filter(fn).length != 0) {}'
   ],
 
   invalid: [
@@ -326,6 +359,364 @@ ruleTester.run('prefer-array-some', preferArraySome, {
           column: 5,
           endLine: 1,
           endColumn: 26
+        }
+      ]
+    },
+
+    // --- filter().length cases ---
+
+    // filter().length > 0 -> arr.some(fn)
+    {
+      code: 'if (arr.filter(fn).length > 0) {}',
+      output: 'if (arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 30
+        }
+      ]
+    },
+    {
+      code: 'if (arr.filter(x => x.active).length > 0) {}',
+      output: 'if (arr.some(x => x.active)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 41
+        }
+      ]
+    },
+
+    // filter().length !== 0 -> arr.some(fn)
+    {
+      code: 'if (arr.filter(fn).length !== 0) {}',
+      output: 'if (arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 32
+        }
+      ]
+    },
+
+    // filter().length >= 1 -> arr.some(fn)
+    {
+      code: 'if (arr.filter(fn).length >= 1) {}',
+      output: 'if (arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    },
+
+    // filter().length === 0 -> !arr.some(fn)
+    {
+      code: 'if (arr.filter(fn).length === 0) {}',
+      output: 'if (!arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 32
+        }
+      ]
+    },
+
+    // filter().length < 1 -> !arr.some(fn)
+    {
+      code: 'if (arr.filter(fn).length < 1) {}',
+      output: 'if (!arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 30
+        }
+      ]
+    },
+
+    // flipped operands: 0 < filter().length -> arr.some(fn)
+    {
+      code: 'if (0 < arr.filter(fn).length) {}',
+      output: 'if (arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 30
+        }
+      ]
+    },
+    {
+      code: 'if (0 !== arr.filter(fn).length) {}',
+      output: 'if (arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 32
+        }
+      ]
+    },
+    {
+      code: 'if (1 <= arr.filter(fn).length) {}',
+      output: 'if (arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    },
+    {
+      code: 'if (0 === arr.filter(fn).length) {}',
+      output: 'if (!arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 32
+        }
+      ]
+    },
+    {
+      code: 'if (1 > arr.filter(fn).length) {}',
+      output: 'if (!arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 30
+        }
+      ]
+    },
+
+    // filter().length in boolean context (truthy)
+    {
+      code: 'if (arr.filter(fn).length) {}',
+      output: 'if (arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 26
+        }
+      ]
+    },
+    {
+      code: 'while (arr.filter(fn).length) {}',
+      output: 'while (arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 8,
+          endLine: 1,
+          endColumn: 29
+        }
+      ]
+    },
+    {
+      code: 'const result = arr.filter(fn).length ? "yes" : "no";',
+      output: 'const result = arr.some(fn) ? "yes" : "no";',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 16,
+          endLine: 1,
+          endColumn: 37
+        }
+      ]
+    },
+
+    // !filter().length -> !arr.some(fn)
+    {
+      code: 'if (!arr.filter(fn).length) {}',
+      output: 'if (!arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 27
+        }
+      ]
+    },
+
+    // !!filter().length -> arr.some(fn)
+    {
+      code: 'if (!!arr.filter(fn).length) {}',
+      output: 'if (arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 28
+        }
+      ]
+    },
+    {
+      code: 'const exists = !!arr.filter(fn).length;',
+      output: 'const exists = arr.some(fn);',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 16,
+          endLine: 1,
+          endColumn: 39
+        }
+      ]
+    },
+
+    // with thisArg
+    {
+      code: 'if (arr.filter(fn, thisArg).length > 0) {}',
+      output: 'if (arr.some(fn, thisArg)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 39
+        }
+      ]
+    },
+
+    // member expression / chained object access
+    {
+      code: 'if (this.items.filter(fn).length > 0) {}',
+      output: 'if (this.items.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 37
+        }
+      ]
+    },
+    {
+      code: 'if (obj.data.arr.filter(x => x.id === id).length > 0) {}',
+      output: 'if (obj.data.arr.some(x => x.id === id)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 53
+        }
+      ]
+    },
+    {
+      code: 'if (getArray().filter(item => item.active).length > 0) {}',
+      output: 'if (getArray().some(item => item.active)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 54
+        }
+      ]
+    },
+
+    // bracket notation for .length
+    {
+      code: 'if (arr.filter(fn)["length"] > 0) {}',
+      output: 'if (arr.some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 33
+        }
+      ]
+    },
+
+    // used in logical expression
+    {
+      code: 'if (arr.filter(fn).length > 0 && otherCondition) {}',
+      output: 'if (arr.some(fn) && otherCondition) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 30
+        }
+      ]
+    },
+
+    // assignment context (exists as boolean)
+    {
+      code: 'const exists = arr.filter(fn).length > 0;',
+      output: 'const exists = arr.some(fn);',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 16,
+          endLine: 1,
+          endColumn: 41
+        }
+      ]
+    },
+
+    // chained filter — fixes the outer .filter().length, leaves inner .filter() in place;
+    // arr.filter(fn1).some(fn2) is correct, just not maximally optimal
+    {
+      code: 'if (arr.filter(fn1).filter(fn2).length > 0) {}',
+      output: 'if (arr.filter(fn1).some(fn2)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 43
         }
       ]
     }

--- a/src/rules/prefer-array-some.ts
+++ b/src/rules/prefer-array-some.ts
@@ -1,20 +1,50 @@
 import type {Rule} from 'eslint';
 import type {
   BinaryExpression,
+  BinaryOperator,
   CallExpression,
-  UnaryExpression,
   Expression,
-  Node
+  Literal,
+  Identifier,
+  PrivateIdentifier,
+  MemberExpression,
+  Node,
+  UnaryExpression
 } from 'estree';
 import {isInBooleanContext, isNullish} from '../utils/ast.js';
 
-function isFindCall(node: Expression): node is CallExpression {
+function isIdentifierOrStringLiteral(
+  identifierName: string,
+  node: Expression | PrivateIdentifier
+): node is Identifier | Literal {
   return (
-    node.type === 'CallExpression' &&
-    node.callee.type === 'MemberExpression' &&
-    node.callee.property.type === 'Identifier' &&
-    node.callee.property.name === 'find' &&
-    node.arguments.length >= 1
+    (node.type === 'Identifier' && node.name === identifierName) ||
+    (node.type === 'Literal' && node.value === identifierName)
+  );
+}
+
+function isArrayMethodCall(
+  methodName: string
+): (node: Expression) => node is CallExpression {
+  return function (node: Expression): node is CallExpression {
+    return (
+      node.type === 'CallExpression' &&
+      node.callee.type === 'MemberExpression' &&
+      isIdentifierOrStringLiteral(methodName, node.callee.property) &&
+      node.arguments.length >= 1
+    );
+  };
+}
+
+const isFindCall = isArrayMethodCall('find');
+const isFilterCall = isArrayMethodCall('filter');
+
+function isFilterLengthCall(node: Expression): node is MemberExpression {
+  return (
+    node.type === 'MemberExpression' &&
+    isIdentifierOrStringLiteral('length', node.property) &&
+    node.object.type === 'CallExpression' &&
+    isFilterCall(node.object)
   );
 }
 
@@ -47,6 +77,38 @@ function reportFind(
   });
 }
 
+function reportFilterLength(
+  context: Rule.RuleContext,
+  node: Node,
+  filterLengthCall: MemberExpression,
+  shouldNegate: boolean
+) {
+  if (filterLengthCall.object.type !== 'CallExpression') {
+    return;
+  }
+  if (filterLengthCall.object.callee.type !== 'MemberExpression') {
+    return;
+  }
+
+  const sourceCode = context.sourceCode;
+  const arrayText = sourceCode.getText(filterLengthCall.object.callee.object);
+  const argsText = filterLengthCall.object.arguments
+    .map((arg) => sourceCode.getText(arg))
+    .join(', ');
+
+  const replacement = shouldNegate
+    ? `!${arrayText}.some(${argsText})`
+    : `${arrayText}.some(${argsText})`;
+
+  context.report({
+    node,
+    messageId: 'preferArraySome',
+    fix(fixer) {
+      return fixer.replaceText(node, replacement);
+    }
+  });
+}
+
 function checkBinaryExpression(
   node: BinaryExpression & Rule.NodeParentExtension,
   context: Rule.RuleContext
@@ -57,7 +119,8 @@ function checkBinaryExpression(
     return;
   }
 
-  let findCall: CallExpression;
+  let findCall: CallExpression | undefined;
+  let filterLengthCall: MemberExpression | undefined;
   let constantSide: Expression;
 
   if (isFindCall(left)) {
@@ -66,22 +129,58 @@ function checkBinaryExpression(
   } else if (isFindCall(right)) {
     findCall = right;
     constantSide = left;
+  } else if (isFilterLengthCall(left)) {
+    filterLengthCall = left;
+    constantSide = right;
+  } else if (isFilterLengthCall(right)) {
+    filterLengthCall = right;
+    constantSide = left;
   } else {
     return;
   }
 
-  const nullishType = isNullish(constantSide);
-  if (!nullishType) {
-    return;
-  }
-
-  if (operator === '===' || operator === '!==') {
-    if (nullishType !== 'undefined') {
+  if (findCall !== undefined) {
+    const nullishType = isNullish(constantSide);
+    if (!nullishType) {
       return;
     }
-    const shouldNegate = operator === '===';
-    reportFind(context, node, findCall, shouldNegate);
-    return;
+
+    if (operator === '===' || operator === '!==') {
+      if (nullishType !== 'undefined') {
+        return;
+      }
+      const shouldNegate = operator === '===';
+      reportFind(context, node, findCall, shouldNegate);
+      return;
+    }
+  } else if (filterLengthCall !== undefined) {
+    // Map the operator direction to effectively be filterLengthSide <op> constantSide
+    let ltrOperator = operator;
+    if (left === constantSide) {
+      ltrOperator =
+        (
+          {
+            '>': '<',
+            '<': '>',
+            '<=': '>=',
+            '>=': '<='
+          } as Partial<Record<BinaryOperator, BinaryOperator>>
+        )[operator] ?? operator;
+    }
+
+    if (constantSide.type === 'Literal' && constantSide.value === 0) {
+      if (ltrOperator === '===' || ltrOperator === '<=') {
+        reportFilterLength(context, node, filterLengthCall, true);
+      } else if (ltrOperator === '!==' || ltrOperator === '>') {
+        reportFilterLength(context, node, filterLengthCall, false);
+      }
+    } else if (constantSide.type === 'Literal' && constantSide.value === 1) {
+      if (ltrOperator === '<') {
+        reportFilterLength(context, node, filterLengthCall, true);
+      } else if (ltrOperator === '>=') {
+        reportFilterLength(context, node, filterLengthCall, false);
+      }
+    }
   }
 }
 
@@ -95,6 +194,12 @@ function checkUnaryExpression(
     return;
   }
 
+  // !arr.filter(fn).length -> !array.some(fn)
+  if (node.operator === '!' && isFilterLengthCall(node.argument)) {
+    reportFilterLength(context, node, node.argument, true);
+    return;
+  }
+
   // !!arr.find(fn) -> arr.some(fn)
   if (
     node.operator === '!' &&
@@ -105,6 +210,16 @@ function checkUnaryExpression(
     reportFind(context, node, node.argument.argument, false);
     return;
   }
+
+  // !!arr.filter(fn).length -> arr.some(fn)
+  if (
+    node.operator === '!' &&
+    node.argument.type === 'UnaryExpression' &&
+    node.argument.operator === '!' &&
+    isFilterLengthCall(node.argument.argument)
+  ) {
+    reportFilterLength(context, node, node.argument.argument, false);
+  }
 }
 
 export const preferArraySome: Rule.RuleModule = {
@@ -112,14 +227,14 @@ export const preferArraySome: Rule.RuleModule = {
     type: 'suggestion',
     docs: {
       description:
-        'Prefer Array.some() over Array.find() when checking for element existence',
+        'Prefer Array.some() over Array.find() and Array.filter().length checks when checking for element existence',
       recommended: true
     },
     fixable: 'code',
     schema: [],
     messages: {
       preferArraySome:
-        'Use Array.some() instead of Array.find() when checking for element existence'
+        'Use Array.some() instead of Array.find() and Array.filter().length checks when checking for element existence'
     }
   },
   create(context) {
@@ -155,6 +270,23 @@ export const preferArraySome: Rule.RuleModule = {
 
         if (isInBooleanContext(node)) {
           reportFind(context, node, node, false);
+        }
+      },
+      MemberExpression(node: MemberExpression & Rule.NodeParentExtension) {
+        // Skip if handled by UnaryExpression or BinaryExpression
+        if (
+          node.parent?.type === 'UnaryExpression' ||
+          node.parent?.type === 'BinaryExpression'
+        ) {
+          return;
+        }
+
+        if (!isFilterLengthCall(node)) {
+          return;
+        }
+
+        if (isInBooleanContext(node)) {
+          reportFilterLength(context, node, node, false);
         }
       }
     };


### PR DESCRIPTION
Extend `prefer-array-some` to cover `array.filter(fn).length` checks

Covers numeric comparisons (`> 0`, `!== 0`, `>= 1` and negations), flipped operands, boolean context, and `!`/`!!` prefixes. Updates rule description and README to match.

Not flagged:
- `filter().length` with no args — `.some()` with no args throws TypeError
- Quantity comparisons (`> 1`, `=== 3` etc.) — not existence checks
- Always-true/false patterns (`>= 0`, `< 0`) — logic bugs, out of scope
- Loose equality (`== 0`, `!= 0`) — strict only

Also refactors `isFindCall` into a shared `isArrayMethodCall` helper, which as a side effect extends existing `find` (and new `filter`) detection to also match on string property access (e.g. `arr['find'](fn)`).