### PR TITLE
fix(prefer-spread-syntax): skip non-array concat receivers

### DIFF
--- a/src/rules/prefer-spread-syntax.test.ts
+++ b/src/rules/prefer-spread-syntax.test.ts
@@ -39,6 +39,13 @@ ruleTester.run('prefer-spread-syntax (untyped)', preferSpreadSyntax as never, {
     'Buffer.concat([buf1, buf2]);',
     'Buffer.concat(buffers);',
 
+    "'a'.concat('b');",
+    '`hello`.concat(` world`);',
+    'const stringWithConcat = "StringWithSubstring".substring(1, 5).concat("test");',
+    'String(value).concat(suffix);',
+    'JSON.stringify(value).concat("\\n");',
+    'arr.join(",").concat(suffix);',
+
     // Array.from with mapper function (should keep as-is)
     'Array.from(iterable, x => x * 2);',
     'Array.from(arr, mapper);',
@@ -143,6 +150,12 @@ ruleTester.run('prefer-spread-syntax (untyped)', preferSpreadSyntax as never, {
     {
       code: 'const result = arr.concat(Object.keys(obj));',
       output: 'const result = [...arr, ...Object.keys(obj)];',
+      errors: [{messageId: 'preferSpreadArray'}]
+    },
+
+    {
+      code: 'const result = Object.keys(obj).concat(other);',
+      output: 'const result = [...Object.keys(obj), other];',
       errors: [{messageId: 'preferSpreadArray'}]
     },
 

--- a/src/rules/prefer-spread-syntax.ts
+++ b/src/rules/prefer-spread-syntax.ts
@@ -15,6 +15,82 @@ function isNullOrUndefined(node: TSESTree.Expression): boolean {
   return node.type === 'Identifier' && node.name === 'undefined';
 }
 
+const nonArrayReturningMethods = new Set([
+  'charAt',
+  'charCodeAt',
+  'codePointAt',
+  'endsWith',
+  'includes',
+  'indexOf',
+  'join',
+  'lastIndexOf',
+  'localeCompare',
+  'normalize',
+  'padEnd',
+  'padStart',
+  'repeat',
+  'replace',
+  'replaceAll',
+  'startsWith',
+  'substring',
+  'toExponential',
+  'toFixed',
+  'toLocaleLowerCase',
+  'toLocaleString',
+  'toLocaleUpperCase',
+  'toLowerCase',
+  'toPrecision',
+  'toString',
+  'toUpperCase',
+  'trim',
+  'trimEnd',
+  'trimStart'
+]);
+const primitiveCoercionFunctions = new Set([
+  'BigInt',
+  'Boolean',
+  'Number',
+  'String'
+]);
+
+function isKnownNonArrayConcatReceiver(node: TSESTree.Node): boolean {
+  switch (node.type) {
+    case 'Literal':
+    case 'ObjectExpression':
+    case 'TemplateLiteral':
+      return true;
+  }
+
+  if (node.type !== 'CallExpression') {
+    return false;
+  }
+
+  const {callee} = node;
+  if (
+    callee.type === 'Identifier' &&
+    primitiveCoercionFunctions.has(callee.name)
+  ) {
+    return true;
+  }
+
+  if (
+    callee.type !== 'MemberExpression' ||
+    callee.property.type !== 'Identifier'
+  ) {
+    return false;
+  }
+
+  if (
+    callee.object.type === 'Identifier' &&
+    callee.object.name === 'JSON' &&
+    callee.property.name === 'stringify'
+  ) {
+    return true;
+  }
+
+  return nonArrayReturningMethods.has(callee.property.name);
+}
+
 export const preferSpreadSyntax: TSESLint.RuleModule<MessageIds, []> = {
   meta: {
     type: 'suggestion',
@@ -59,15 +135,19 @@ export const preferSpreadSyntax: TSESLint.RuleModule<MessageIds, []> = {
             node.callee.object.name === 'Buffer'
           )
         ) {
-          // If type info is available, only flag when the receiver is an array
-          if (isArrayType(node.callee.object, context) === false) {
+          const receiver = node.callee.object;
+          const receiverArrayType = isArrayType(receiver, context);
+          if (
+            receiverArrayType === false ||
+            (receiverArrayType !== true &&
+              isKnownNonArrayConcatReceiver(receiver))
+          ) {
             return;
           }
 
           const parts: string[] = [];
 
           // For array literals, inline elements; otherwise spread
-          const receiver = node.callee.object;
           if (receiver.type === 'ArrayExpression') {
             for (const el of receiver.elements) {
               if (el) {


### PR DESCRIPTION
## Summary

Avoid reporting `prefer-spread-syntax` for `concat()` calls whose receiver is clearly not an array, such as string literals, template literals, primitive coercions, string-returning methods, and `JSON.stringify()`.

This prevents unsafe fixes like turning string concatenation into array spread syntax while keeping array-producing receivers fixable.

Covers the false positive demonstrated in #133.

## Verification

- `npm test -- src/rules/prefer-spread-syntax.test.ts`
- `npm run lint`
- `npm run build`