### PR TITLE
fix(prefer-flatmap-over-map-flat): drop blank fixer line

### DIFF
--- a/src/rules/prefer-flatmap-over-map-flat.test.ts
+++ b/src/rules/prefer-flatmap-over-map-flat.test.ts
@@ -92,6 +92,26 @@ ruleTester.run('prefer-flatmap-over-map-flat', preferFlatMapOverMapFlat, {
       code: '(arr.map(fn)).flat();',
       output: '(arr.flatMap(fn));',
       errors: [{messageId: 'preferFlatMap'}]
+    },
+    {
+      code: 'group\n  .map(d => d.refs)\n  .flat()\n  .filter(x);',
+      output: 'group\n  .flatMap(d => d.refs)\n  .filter(x);',
+      errors: [{messageId: 'preferFlatMap'}]
+    },
+    {
+      code: 'standards\n  .map(fn)\n  .flat();',
+      output: 'standards\n  .flatMap(fn);',
+      errors: [{messageId: 'preferFlatMap'}]
+    },
+    {
+      code: 'arr\n  .map(fn)\n  // keep me\n  .flat();',
+      output: 'arr\n  .flatMap(fn)\n  // keep me\n  ;',
+      errors: [{messageId: 'preferFlatMap'}]
+    },
+    {
+      code: '(arr.map(fn))\n  .flat();',
+      output: '(arr.flatMap(fn));',
+      errors: [{messageId: 'preferFlatMap'}]
     }
   ]
 });

--- a/src/rules/prefer-flatmap-over-map-flat.ts
+++ b/src/rules/prefer-flatmap-over-map-flat.ts
@@ -64,9 +64,20 @@ export const preferFlatMapOverMapFlat: Rule.RuleModule = {
             const mapProperty = inner.callee.property;
             const dotToken = sourceCode.getTokenBefore(node.callee.property);
             if (!dotToken) return null;
+            const previousToken = sourceCode.getTokenBefore(dotToken);
+            const gap = previousToken
+              ? sourceCode.text.slice(
+                  previousToken.range![1],
+                  dotToken.range![0]
+                )
+              : '';
+            const removeStart =
+              previousToken && gap.includes('\n') && gap.trim() === ''
+                ? previousToken.range![1]
+                : dotToken.range![0];
             return [
               fixer.replaceText(mapProperty, 'flatMap'),
-              fixer.removeRange([dotToken.range![0], node.range![1]])
+              fixer.removeRange([removeStart, node.range![1]])
             ];
           }
         });


### PR DESCRIPTION
## Summary

Avoid leaving an indented blank line when fixing multi-line `.map(...).flat()` chains where `.flat()` sits on its own line.

The fixer now removes the whitespace gap before `.flat()` only when that gap is purely whitespace with a newline, preserving comment-bearing cases and parenthesized chains.

## Verification

- `npm test -- src/rules/prefer-flatmap-over-map-flat.test.ts`
- `npm run build`
- `npm run lint`