### PR TITLE
feat(prefer-slice-over-split-index): add rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Read more at the
 | [prefer-charcode-at-in-loop](./src/rules/prefer-charcode-at-in-loop.ts) | Prefer `charCodeAt()` over indexed string access for single-character comparisons inside loops | ✖️ | 💡 | 🔶 |
 | [no-delete-property](./src/rules/no-delete-property.ts) | Disallow `delete` on properties — V8 deoptimizes the object to dictionary mode | ✖️ | 💡 | ✖️ |
 | [prefer-flatmap-over-map-flat](./src/rules/prefer-flatmap-over-map-flat.ts) | Prefer `Array.prototype.flatMap()` over `.map(fn).flat()` to skip the intermediate array | ✖️ | ✅ | ✖️ |
-| [prefer-slice-over-split-index](./src/rules/prefer-slice-over-split-index.ts) | Prefer `indexOf()` and `slice()` over `split()[0]`/`split()[1]` when only one piece is needed | ✖️ | ✖️ | ✖️ |
+| [prefer-slice-over-split-index](./src/rules/prefer-slice-over-split-index.ts) | Prefer `indexOf(needle)` and `slice(...)` over `split()[N]` when splitting a string into two pieces | ✖️ | ✖️ | ✖️ |
 | [no-spread-in-reduce](./src/rules/no-spread-in-reduce.ts) | Disallow spreading the accumulator inside a `.reduce()` callback — it's O(N²) | ✖️ | ✖️ | ✖️ |
 | [prefer-static-collator](./src/rules/prefer-static-collator.ts) | Prefer hoisting an `Intl.Collator` over calling `localeCompare` inside a `sort`/`toSorted` callback | ✖️ | ✖️ | ✖️ |
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Read more at the
 | [prefer-includes-over-regex-test](./src/rules/prefer-includes-over-regex-test.ts) | Prefer `s.includes()` / `startsWith` / `endsWith` over `/literal/.test(s)` when the regex has no metacharacters or flags | ✖️ | ✅ | ✖️ |
 | [no-delete-property](./src/rules/no-delete-property.ts) | Disallow `delete` on properties — V8 deoptimizes the object to dictionary mode | ✖️ | 💡 | ✖️ |
 | [prefer-flatmap-over-map-flat](./src/rules/prefer-flatmap-over-map-flat.ts) | Prefer `Array.prototype.flatMap()` over `.map(fn).flat()` to skip the intermediate array | ✖️ | ✅ | ✖️ |
+| [prefer-slice-over-split-index](./src/rules/prefer-slice-over-split-index.ts) | Prefer `indexOf()` and `slice()` over `split()[0]`/`split()[1]` when only one piece is needed | ✖️ | ✖️ | ✖️ |
 | [no-spread-in-reduce](./src/rules/no-spread-in-reduce.ts) | Disallow spreading the accumulator inside a `.reduce()` callback — it's O(N²) | ✖️ | ✖️ | ✖️ |
 | [prefer-static-collator](./src/rules/prefer-static-collator.ts) | Prefer hoisting an `Intl.Collator` over calling `localeCompare` inside a `sort`/`toSorted` callback | ✖️ | ✖️ | ✖️ |
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,7 @@ import {noSpreadInReduce} from './rules/no-spread-in-reduce.js';
 import {preferFlatMapOverMapFlat} from './rules/prefer-flatmap-over-map-flat.js';
 import {preferStaticCollator} from './rules/prefer-static-collator.js';
 import {preferGetOrInsert} from './rules/prefer-get-or-insert.js';
+import {preferSliceOverSplitIndex} from './rules/prefer-slice-over-split-index.js';
 
 const plugin: ESLint.Plugin = {
   meta: {
@@ -64,6 +65,7 @@ const plugin: ESLint.Plugin = {
     'prefer-flatmap-over-map-flat': preferFlatMapOverMapFlat,
     'prefer-static-collator': preferStaticCollator,
     'prefer-get-or-insert': preferGetOrInsert,
+    'prefer-slice-over-split-index': preferSliceOverSplitIndex,
     'ban-dependencies': banDependencies
   }
 };

--- a/src/rules/prefer-slice-over-split-index.test.ts
+++ b/src/rules/prefer-slice-over-split-index.test.ts
@@ -1,0 +1,94 @@
+import {RuleTester} from 'eslint';
+import {preferSliceOverSplitIndex} from './prefer-slice-over-split-index.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('prefer-slice-over-split-index', preferSliceOverSplitIndex, {
+  valid: [
+    'const x = s.slice(0, s.indexOf("/"));',
+    'const x = s.indexOf("/") < 0 ? s : s.slice(0, s.indexOf("/"));',
+    's.split("/").map(x => x);',
+    's.split("/").pop();',
+    's.split("/").length;',
+    's.split(",")[2];',
+    's.split(".")[5];',
+    's.split(",").length;',
+    's.split(",")[i];',
+    's.split(",")[idx];',
+    's.split()[0];',
+    's.split("")[0];',
+    's.split(/\\?|#/)[0];',
+    's.split(separator)[0];',
+    's.split(`${separator}`)[0];',
+    's.split(",", limit)[0];',
+    's.split(",", 0)[0];',
+    's.split(",", 0)[1];',
+    's.split(",", 1)[1];',
+    's.split(",", 1.5)[0];',
+    's.split(",", -1)[0];',
+    's.split(",", 2, extra)[0];',
+    'arr[0];',
+    'fn()[0];',
+    'obj.method()[0];'
+  ],
+
+  invalid: [
+    {
+      code: 'const head = s.split("/")[0];',
+      errors: [
+        {
+          messageId: 'preferSliceFirst',
+          line: 1,
+          column: 14
+        }
+      ]
+    },
+    {
+      code: 'const head = s.split(`/`)[0];',
+      errors: [{messageId: 'preferSliceFirst'}]
+    },
+    {
+      code: 'const head = s.split(",", 1)[0];',
+      errors: [{messageId: 'preferSliceFirst'}]
+    },
+    {
+      code: 'const head = s.split(",", 2)[0];',
+      errors: [{messageId: 'preferSliceFirst'}]
+    },
+    {
+      code: 'const tail = s.split("=")[1];',
+      errors: [
+        {
+          messageId: 'preferSliceSecond',
+          line: 1,
+          column: 14
+        }
+      ]
+    },
+    {
+      code: 'const tail = s.split("=", 2)[1];',
+      errors: [{messageId: 'preferSliceSecond'}]
+    },
+    {
+      code: 'const head = url.toLowerCase().split("?")[0];',
+      errors: [{messageId: 'preferSliceFirst'}]
+    },
+    {
+      code: 'arr.map(x => x?.split(":")[0]);',
+      errors: [{messageId: 'preferSliceFirst'}]
+    },
+    {
+      code: 'const head = msg.split("\\n", 1)[0];',
+      errors: [{messageId: 'preferSliceFirst'}]
+    },
+    {
+      code: 'doStuff(line.split(":")[0]);',
+      errors: [{messageId: 'preferSliceFirst'}]
+    }
+  ]
+});

--- a/src/rules/prefer-slice-over-split-index.ts
+++ b/src/rules/prefer-slice-over-split-index.ts
@@ -1,7 +1,6 @@
 import type {
   CallExpression,
   Expression,
-  Literal,
   MemberExpression,
   SpreadElement
 } from 'estree';
@@ -24,7 +23,7 @@ function isSupportedLimit(
 ): boolean {
   if (!limit) return true;
   if (limit.type !== 'Literal') return false;
-  const {value} = limit as Literal;
+  const {value} = limit;
   return typeof value === 'number' && Number.isInteger(value) && value > index;
 }
 
@@ -48,15 +47,15 @@ export const preferSliceOverSplitIndex: Rule.RuleModule = {
     type: 'suggestion',
     docs: {
       description:
-        'Prefer indexOf and slice over split()[N] when only the first or second piece is needed',
+        'Prefer `indexOf(needle)` and `slice(...)` over `split()[N]` when splitting a string into two pieces.',
       recommended: false
     },
     schema: [],
     messages: {
       preferSliceFirst:
-        'Prefer indexOf()+slice() over split(separator)[0] for string separators; split allocates an intermediate array. Preserve the missing-separator fallback explicitly.',
+        'Prefer `indexOf(needle)` and `slice(0, index)` over `split(needle)[0]` for string separators. `split` will allocate an intermediate array, resulting in poorer performance. Preserve the missing-separator fallback explicitly.',
       preferSliceSecond:
-        'Prefer indexOf()+slice() over split(separator)[1] for string separators; split allocates an intermediate array. Preserve missing and repeated-separator behavior explicitly.'
+        'Prefer `indexOf(needle)` and `slice(index)` over `split(needle)[1]` for string separators. `split` will allocate an intermediate array, resulting in poorer performance. Preserve the missing-separator fallback explicitly.'
     }
   },
   create(context) {

--- a/src/rules/prefer-slice-over-split-index.ts
+++ b/src/rules/prefer-slice-over-split-index.ts
@@ -1,0 +1,81 @@
+import type {
+  CallExpression,
+  Expression,
+  Literal,
+  MemberExpression,
+  SpreadElement
+} from 'estree';
+import type {Rule} from 'eslint';
+
+function stringValue(node: Expression | SpreadElement): string | null {
+  if (node.type === 'Literal') {
+    return typeof node.value === 'string' ? node.value : null;
+  }
+  if (node.type === 'TemplateLiteral' && node.expressions.length === 0) {
+    const cooked = node.quasis[0]?.value.cooked;
+    return typeof cooked === 'string' ? cooked : null;
+  }
+  return null;
+}
+
+function isSupportedLimit(
+  limit: Expression | SpreadElement | undefined,
+  index: 0 | 1
+): boolean {
+  if (!limit) return true;
+  if (limit.type !== 'Literal') return false;
+  const {value} = limit as Literal;
+  return typeof value === 'number' && Number.isInteger(value) && value > index;
+}
+
+function getSplitCall(node: MemberExpression): CallExpression | null {
+  const call = node.object;
+  if (call.type !== 'CallExpression') return null;
+  const callee = call.callee;
+  if (callee.type !== 'MemberExpression' || callee.computed) return null;
+  if (callee.property.type !== 'Identifier' || callee.property.name !== 'split')
+    return null;
+  if (call.arguments.length === 0 || call.arguments.length > 2) return null;
+  const separator = call.arguments[0];
+  if (!separator) return null;
+  const value = stringValue(separator);
+  if (value === null || value.length === 0) return null;
+  return call;
+}
+
+export const preferSliceOverSplitIndex: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer indexOf and slice over split()[N] when only the first or second piece is needed',
+      recommended: false
+    },
+    schema: [],
+    messages: {
+      preferSliceFirst:
+        'Prefer indexOf()+slice() over split(separator)[0] for string separators; split allocates an intermediate array. Preserve the missing-separator fallback explicitly.',
+      preferSliceSecond:
+        'Prefer indexOf()+slice() over split(separator)[1] for string separators; split allocates an intermediate array. Preserve missing and repeated-separator behavior explicitly.'
+    }
+  },
+  create(context) {
+    return {
+      MemberExpression(node: MemberExpression) {
+        if (!node.computed) return;
+        if (node.property.type !== 'Literal') return;
+        const index = node.property.value;
+        if (index !== 0 && index !== 1) return;
+
+        const call = getSplitCall(node);
+        if (!call) return;
+        if (!isSupportedLimit(call.arguments[1], index)) return;
+
+        context.report({
+          node,
+          messageId: index === 0 ? 'preferSliceFirst' : 'preferSliceSecond'
+        });
+      }
+    };
+  }
+};


### PR DESCRIPTION
## Summary

Add `prefer-slice-over-split-index` to report `split(<string>)[0]` and `split(<string>)[1]` when only one piece is needed.

The rule targets non-empty string separators and skips regex separators, unknown separators, empty-string splits, and split limits that change the indexed result.

This is opt-in only and is not enabled in the recommended/performance config by default.

A quick benchmark on Node 24 showed equivalent `indexOf()`/`slice()` forms were roughly 3x-4.5x faster than `split()[0|1]`.

## Verification

- `npm test -- src/rules/prefer-slice-over-split-index.test.ts`
- `npm run lint`
- `npm run build`
- `npm test`