### PR TITLE
feat(prefer-charcode-at-in-loop): add rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Read more at the
 | [prefer-inline-equality](./src/rules/prefer-inline-equality.ts) | Prefer inline equality checks over temporary object creation for simple comparisons | ✖️ | ✅ | 🔶 |
 | [prefer-string-fromcharcode](./src/rules/prefer-string-fromcharcode.ts) | Prefer `String.fromCharCode()` over `String.fromCodePoint()` for code points below `0x10000` | ✅ | ✅ | ✖️ |
 | [prefer-includes-over-regex-test](./src/rules/prefer-includes-over-regex-test.ts) | Prefer `s.includes()` / `startsWith` / `endsWith` over `/literal/.test(s)` when the regex has no metacharacters or flags | ✖️ | ✅ | ✖️ |
+| [prefer-charcode-at-in-loop](./src/rules/prefer-charcode-at-in-loop.ts) | Prefer `charCodeAt()` over indexed string access for single-character comparisons inside loops | ✖️ | 💡 | 🔶 |
 | [no-delete-property](./src/rules/no-delete-property.ts) | Disallow `delete` on properties — V8 deoptimizes the object to dictionary mode | ✖️ | 💡 | ✖️ |
 | [prefer-flatmap-over-map-flat](./src/rules/prefer-flatmap-over-map-flat.ts) | Prefer `Array.prototype.flatMap()` over `.map(fn).flat()` to skip the intermediate array | ✖️ | ✅ | ✖️ |
 | [no-spread-in-reduce](./src/rules/no-spread-in-reduce.ts) | Disallow spreading the accumulator inside a `.reduce()` callback — it's O(N²) | ✖️ | ✖️ | ✖️ |

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,7 @@ import {noSpreadInReduce} from './rules/no-spread-in-reduce.js';
 import {preferFlatMapOverMapFlat} from './rules/prefer-flatmap-over-map-flat.js';
 import {preferStaticCollator} from './rules/prefer-static-collator.js';
 import {preferGetOrInsert} from './rules/prefer-get-or-insert.js';
+import {preferCharCodeAtInLoop} from './rules/prefer-charcode-at-in-loop.js';
 
 const plugin: ESLint.Plugin = {
   meta: {
@@ -64,6 +65,8 @@ const plugin: ESLint.Plugin = {
     'prefer-flatmap-over-map-flat': preferFlatMapOverMapFlat,
     'prefer-static-collator': preferStaticCollator,
     'prefer-get-or-insert': preferGetOrInsert,
+    'prefer-charcode-at-in-loop':
+      preferCharCodeAtInLoop as never as Rule.RuleModule,
     'ban-dependencies': banDependencies
   }
 };

--- a/src/rules/prefer-charcode-at-in-loop.test.ts
+++ b/src/rules/prefer-charcode-at-in-loop.test.ts
@@ -1,0 +1,176 @@
+import {RuleTester} from 'eslint';
+import {RuleTester as TSRuleTester} from '@typescript-eslint/rule-tester';
+import {preferCharCodeAtInLoop} from './prefer-charcode-at-in-loop.js';
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const rootDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..'
+);
+const typedRuleTester = new TSRuleTester({
+  languageOptions: {
+    parserOptions: {
+      projectService: {
+        allowDefaultProject: ['*.ts'],
+        defaultProject: './tsconfig.json'
+      },
+      tsconfigRootDir: rootDir
+    }
+  }
+});
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run(
+  'prefer-charcode-at-in-loop (untyped)',
+  preferCharCodeAtInLoop as never,
+  {
+    valid: [
+      "if ('abc'[0] === 'a') {}",
+      "for (let i = 0; i < n; i++) { if (str[i] === '/') {} }",
+      "for (const char of chars) { if (char === 'a') {} }",
+      "for (const x of arr) { if (str[i] === 'ab') {} }",
+      "for (const x of arr) { if (str[i] === '') {} }",
+      "for (const x of arr) { if (str[i] < 'a') {} }",
+      "for (const x of arr) { if (str.x === 'a') {} }",
+      "for (let i = 0; i < n; i++) { if (str?.[i] === '/') {} }",
+      'for (let i = 0; i < n; i++) { if (str[i] === other[i]) {} }',
+      "for (const x of arr) { if ('abc'['x'] === 'a') {} }",
+      "for (const x of arr) { if ('abc'[1.5] === 'a') {} }",
+      "for (const x of arr) { function inner() { return 'abc'[0] === 'a'; } }",
+      "for (const x of arr) { const f = () => 'abc'[0] === 'a'; }"
+    ],
+
+    invalid: [
+      {
+        code: "for (let i = 0; i < 3; i++) { if ('abc'[i] === 'a') break; }",
+        errors: [
+          {
+            messageId: 'preferCharCodeAt',
+            suggestions: [
+              {
+                messageId: 'replaceWithCharCodeAt',
+                output:
+                  "for (let i = 0; i < 3; i++) { if ('abc'.charCodeAt(i) === 97) break; }"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        code: "while (i < n) { if (`abc`[i] !== '\\n') i++; }",
+        errors: [
+          {
+            messageId: 'preferCharCodeAt',
+            suggestions: [
+              {
+                messageId: 'replaceWithCharCodeAt',
+                output: 'while (i < n) { if (`abc`.charCodeAt(i) !== 10) i++; }'
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+);
+
+typedRuleTester.run(
+  'prefer-charcode-at-in-loop (typed)',
+  preferCharCodeAtInLoop,
+  {
+    valid: [
+      "const str: string = ''; if (str[0] === '/') {}",
+      "const chars: string[] = []; for (let i = 0; i < chars.length; i++) { if (chars[i] === 'a') {} }",
+      "const values: unknown[] = []; for (let i = 0; i < values.length; i++) { if (values[i] === 'a') {} }",
+      "const str: string = ''; for (let i = 0; i < str.length; i++) { if (str[i] === 'ab') {} }",
+      "const str: string = ''; for (let i = 0; i < str.length; i++) { if (str[i] < 'a') {} }",
+      "declare const s: any; for (let i = 0; i < 3; i++) { if (s[i] === 'a') {} }",
+      "declare const obj: Record<string, unknown>; const str: string = ''; for (const k in obj) { if (str[k] === 'a') {} }",
+      "const str: string = ''; for (let i = 0; i < str.length; i++) { if (str['x'] === 'a') {} }"
+    ],
+
+    invalid: [
+      {
+        code: "const str: string = ''; for (let i = 0; i < str.length; i++) { if (str[i] === '/') break; }",
+        errors: [
+          {
+            messageId: 'preferCharCodeAt',
+            suggestions: [
+              {
+                messageId: 'replaceWithCharCodeAt',
+                output:
+                  "const str: string = ''; for (let i = 0; i < str.length; i++) { if (str.charCodeAt(i) === 47) break; }"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        code: "const str: string = ''; for (let i = 0; i < str.length; i++) { if ('{' === str[i]) {} }",
+        errors: [
+          {
+            messageId: 'preferCharCodeAt',
+            suggestions: [
+              {
+                messageId: 'replaceWithCharCodeAt',
+                output:
+                  "const str: string = ''; for (let i = 0; i < str.length; i++) { if (123 === str.charCodeAt(i)) {} }"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        code: "declare const line: {text: string}; for (const item of items) { if (line.text[0] === '#') {} }",
+        errors: [
+          {
+            messageId: 'preferCharCodeAt',
+            suggestions: [
+              {
+                messageId: 'replaceWithCharCodeAt',
+                output:
+                  'declare const line: {text: string}; for (const item of items) { if (line.text.charCodeAt(0) === 35) {} }'
+              }
+            ]
+          }
+        ]
+      },
+      {
+        code: "function f(dep: string) { for (const item of items) dep[0] !== '!' && use(dep); }",
+        errors: [
+          {
+            messageId: 'preferCharCodeAt',
+            suggestions: [
+              {
+                messageId: 'replaceWithCharCodeAt',
+                output:
+                  'function f(dep: string) { for (const item of items) dep.charCodeAt(0) !== 33 && use(dep); }'
+              }
+            ]
+          }
+        ]
+      },
+      {
+        code: "declare const a: {b: string}; for (const x of arr) { if ((a?.b)[0] === 'a') {} }",
+        errors: [
+          {
+            messageId: 'preferCharCodeAt',
+            suggestions: [
+              {
+                messageId: 'replaceWithCharCodeAt',
+                output:
+                  'declare const a: {b: string}; for (const x of arr) { if ((a?.b).charCodeAt(0) === 97) {} }'
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+);

--- a/src/rules/prefer-charcode-at-in-loop.ts
+++ b/src/rules/prefer-charcode-at-in-loop.ts
@@ -1,0 +1,206 @@
+import type {TSESLint, TSESTree} from '@typescript-eslint/utils';
+import type ts from 'typescript';
+import {needsParensForPropertyAccess} from '../utils/ast.js';
+import {tryGetTypedParserServices} from '../utils/typescript.js';
+
+type MessageIds = 'preferCharCodeAt' | 'replaceWithCharCodeAt';
+
+const EQUALITY_OPERATORS = new Set(['===', '!==', '==', '!=']);
+const LOOP_TYPES = new Set([
+  'ForStatement',
+  'ForInStatement',
+  'ForOfStatement',
+  'WhileStatement',
+  'DoWhileStatement'
+]);
+const FUNCTION_TYPES = new Set([
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'ArrowFunctionExpression'
+]);
+
+function isSingleCharStringLiteral(
+  node: TSESTree.Node
+): node is TSESTree.StringLiteral {
+  return (
+    node.type === 'Literal' &&
+    typeof node.value === 'string' &&
+    node.value.length === 1
+  );
+}
+
+function isComputedMember(
+  node: TSESTree.Node
+): node is TSESTree.MemberExpression {
+  return node.type === 'MemberExpression' && node.computed && !node.optional;
+}
+
+function isStringLiteralExpression(node: TSESTree.Node): boolean {
+  return (
+    (node.type === 'Literal' && typeof node.value === 'string') ||
+    (node.type === 'TemplateLiteral' && node.expressions.length === 0)
+  );
+}
+
+function getTypeInfo(
+  node: TSESTree.Node,
+  context: Readonly<TSESLint.RuleContext<MessageIds, []>>
+): {type: ts.Type; checker: ts.TypeChecker} | null {
+  const services = tryGetTypedParserServices(context);
+  if (!services) {
+    return null;
+  }
+  const type = services.getTypeAtLocation(node);
+  if (!type) {
+    return null;
+  }
+  return {type, checker: services.program.getTypeChecker()};
+}
+
+function isKnownStringExpression(
+  node: TSESTree.Node,
+  context: Readonly<TSESLint.RuleContext<MessageIds, []>>
+): boolean {
+  if (isStringLiteralExpression(node)) {
+    return true;
+  }
+  const info = getTypeInfo(node, context);
+  if (!info) {
+    return false;
+  }
+  if (info.checker.typeToString(info.type) === 'any') {
+    return false;
+  }
+  return info.checker.isTypeAssignableTo(
+    info.type,
+    info.checker.getStringType()
+  );
+}
+
+function isUnsafeIndex(
+  property: TSESTree.Node,
+  context: Readonly<TSESLint.RuleContext<MessageIds, []>>
+): boolean {
+  if (property.type === 'Literal') {
+    return typeof property.value === 'number'
+      ? !Number.isInteger(property.value)
+      : true;
+  }
+  const info = getTypeInfo(property, context);
+  if (!info) {
+    return false;
+  }
+  return !info.checker.isTypeAssignableTo(
+    info.type,
+    info.checker.getNumberType()
+  );
+}
+
+function isInLoop(node: TSESTree.Node): boolean {
+  let current: TSESTree.Node | undefined = node.parent;
+  while (current) {
+    if (FUNCTION_TYPES.has(current.type)) {
+      return false;
+    }
+    if (LOOP_TYPES.has(current.type)) {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+export const preferCharCodeAtInLoop: TSESLint.RuleModule<MessageIds, []> = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer `charCodeAt()` over indexed string access for single-character comparisons inside loops'
+    },
+    hasSuggestions: true,
+    schema: [],
+    messages: {
+      preferCharCodeAt:
+        'Comparing indexed string access to a single-character string can allocate and compare a one-character string. In a loop, charCodeAt() against a numeric code unit is faster.',
+      replaceWithCharCodeAt:
+        'Replace with charCodeAt() and code unit {{code}} for {{quoted}}.'
+    }
+  },
+  defaultOptions: [],
+  create(context) {
+    const sourceCode = context.sourceCode;
+
+    return {
+      BinaryExpression(node: TSESTree.BinaryExpression) {
+        if (!EQUALITY_OPERATORS.has(node.operator)) {
+          return;
+        }
+
+        let member: TSESTree.MemberExpression;
+        let charLiteral: TSESTree.StringLiteral;
+        let charOnRight: boolean;
+
+        if (
+          isComputedMember(node.left) &&
+          isSingleCharStringLiteral(node.right)
+        ) {
+          member = node.left;
+          charLiteral = node.right;
+          charOnRight = true;
+        } else if (
+          isSingleCharStringLiteral(node.left) &&
+          isComputedMember(node.right)
+        ) {
+          member = node.right;
+          charLiteral = node.left;
+          charOnRight = false;
+        } else {
+          return;
+        }
+
+        if (!isInLoop(node)) {
+          return;
+        }
+
+        if (isUnsafeIndex(member.property, context)) {
+          return;
+        }
+
+        if (!isKnownStringExpression(member.object, context)) {
+          return;
+        }
+
+        const rawObjectText = sourceCode.getText(member.object);
+        const objectText =
+          needsParensForPropertyAccess(member.object) ||
+          member.object.type === 'ChainExpression'
+            ? `(${rawObjectText})`
+            : rawObjectText;
+        const indexText = sourceCode.getText(member.property);
+        const char = charLiteral.value;
+        const code = char.charCodeAt(0);
+        const charCodeAtCall = `${objectText}.charCodeAt(${indexText})`;
+        const replacement = charOnRight
+          ? `${charCodeAtCall} ${node.operator} ${code}`
+          : `${code} ${node.operator} ${charCodeAtCall}`;
+
+        context.report({
+          node,
+          messageId: 'preferCharCodeAt',
+          suggest: [
+            {
+              messageId: 'replaceWithCharCodeAt',
+              data: {
+                code: String(code),
+                quoted: JSON.stringify(char)
+              },
+              fix(fixer) {
+                return fixer.replaceText(node, replacement);
+              }
+            }
+          ]
+        });
+      }
+    };
+  }
+};


### PR DESCRIPTION
## Summary

- add opt-in `prefer-charcode-at-in-loop`
- report single-code-unit string comparisons inside loops when the indexed receiver is known to be a string
- provide suggestions to compare `charCodeAt(index)` against the numeric code unit instead of comparing one-character strings

## Notes

This is suggestion-only and not part of the recommended config. It intentionally keeps unknown indexed access valid unless the receiver is a string literal/template or has string type information.

Node `v24.9.0` benchmark on consumer-shaped loops:

- leading-space scan: indexed compare `759.7ms`, `charCodeAt` compare `660.9ms`
- first-character filter: indexed compare `14.7ms`, `charCodeAt` compare `13.4ms`

## Test plan

- `npm test -- src/rules/prefer-charcode-at-in-loop.test.ts`
- `npm run lint`
- `npm run build`