### PR TITLE
feat(prefer-throw-if-no-entry): add rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Read more at the
 | [prefer-string-fromcharcode](./src/rules/prefer-string-fromcharcode.ts) | Prefer `String.fromCharCode()` over `String.fromCodePoint()` for code points below `0x10000` | ✅ | ✅ | ✖️ |
 | [prefer-includes-over-regex-test](./src/rules/prefer-includes-over-regex-test.ts) | Prefer `s.includes()` / `startsWith` / `endsWith` over `/literal/.test(s)` when the regex has no metacharacters or flags | ✖️ | ✅ | ✖️ |
 | [prefer-charcode-at-in-loop](./src/rules/prefer-charcode-at-in-loop.ts) | Prefer `charCodeAt()` over indexed string access for single-character comparisons inside loops | ✖️ | 💡 | 🔶 |
-| [prefer-throw-if-no-entry](./src/rules/prefer-throw-if-no-entry.ts) | Prefer `{throwIfNoEntry: false}` over catching missing fs entries from sync stat calls | ✖️ | 💡 | ✖️ |
+| [prefer-throw-if-no-entry](./src/rules/prefer-throw-if-no-entry.ts) | Prefer `{throwIfNoEntry: false}` over relying on a thrown error for missing fs entries from sync stat calls | ✖️ | 💡 | ✖️ |
 | [no-delete-property](./src/rules/no-delete-property.ts) | Disallow `delete` on properties — V8 deoptimizes the object to dictionary mode | ✖️ | 💡 | ✖️ |
 | [prefer-flatmap-over-map-flat](./src/rules/prefer-flatmap-over-map-flat.ts) | Prefer `Array.prototype.flatMap()` over `.map(fn).flat()` to skip the intermediate array | ✖️ | ✅ | ✖️ |
 | [prefer-slice-over-split-index](./src/rules/prefer-slice-over-split-index.ts) | Prefer `indexOf(needle)` and `slice(...)` over `split()[N]` when splitting a string into two pieces | ✖️ | ✖️ | ✖️ |

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Read more at the
 | [prefer-string-fromcharcode](./src/rules/prefer-string-fromcharcode.ts) | Prefer `String.fromCharCode()` over `String.fromCodePoint()` for code points below `0x10000` | ✅ | ✅ | ✖️ |
 | [prefer-includes-over-regex-test](./src/rules/prefer-includes-over-regex-test.ts) | Prefer `s.includes()` / `startsWith` / `endsWith` over `/literal/.test(s)` when the regex has no metacharacters or flags | ✖️ | ✅ | ✖️ |
 | [prefer-charcode-at-in-loop](./src/rules/prefer-charcode-at-in-loop.ts) | Prefer `charCodeAt()` over indexed string access for single-character comparisons inside loops | ✖️ | 💡 | 🔶 |
+| [prefer-throw-if-no-entry](./src/rules/prefer-throw-if-no-entry.ts) | Prefer `{throwIfNoEntry: false}` over catching missing fs entries from sync stat calls | ✖️ | 💡 | ✖️ |
 | [no-delete-property](./src/rules/no-delete-property.ts) | Disallow `delete` on properties — V8 deoptimizes the object to dictionary mode | ✖️ | 💡 | ✖️ |
 | [prefer-flatmap-over-map-flat](./src/rules/prefer-flatmap-over-map-flat.ts) | Prefer `Array.prototype.flatMap()` over `.map(fn).flat()` to skip the intermediate array | ✖️ | ✅ | ✖️ |
 | [prefer-slice-over-split-index](./src/rules/prefer-slice-over-split-index.ts) | Prefer `indexOf(needle)` and `slice(...)` over `split()[N]` when splitting a string into two pieces | ✖️ | ✖️ | ✖️ |

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ import {preferStaticCollator} from './rules/prefer-static-collator.js';
 import {preferGetOrInsert} from './rules/prefer-get-or-insert.js';
 import {preferCharCodeAtInLoop} from './rules/prefer-charcode-at-in-loop.js';
 import {preferSliceOverSplitIndex} from './rules/prefer-slice-over-split-index.js';
+import {preferThrowIfNoEntry} from './rules/prefer-throw-if-no-entry.js';
 
 const plugin: ESLint.Plugin = {
   meta: {
@@ -69,6 +70,7 @@ const plugin: ESLint.Plugin = {
     'prefer-charcode-at-in-loop':
       preferCharCodeAtInLoop as never as Rule.RuleModule,
     'prefer-slice-over-split-index': preferSliceOverSplitIndex,
+    'prefer-throw-if-no-entry': preferThrowIfNoEntry,
     'ban-dependencies': banDependencies
   }
 };

--- a/src/rules/prefer-throw-if-no-entry.test.ts
+++ b/src/rules/prefer-throw-if-no-entry.test.ts
@@ -33,6 +33,22 @@ ruleTester.run('prefer-throw-if-no-entry', preferThrowIfNoEntry, {
 
   invalid: [
     {
+      code: 'function isDir(p) { try { return statSync(p)?.isDirectory() ?? false; } catch { return false; } }',
+      output: null,
+      errors: [
+        {
+          messageId: 'preferThrowIfNoEntry',
+          suggestions: [
+            {
+              messageId: 'addThrowIfNoEntryOption',
+              output:
+                'function isDir(p) { try { return statSync(p, {throwIfNoEntry: false})?.isDirectory() ?? false; } catch { return false; } }'
+            }
+          ]
+        }
+      ]
+    },
+    {
       code: 'try { statSync(p); } catch {}',
       output: null,
       errors: [

--- a/src/rules/prefer-throw-if-no-entry.test.ts
+++ b/src/rules/prefer-throw-if-no-entry.test.ts
@@ -1,0 +1,254 @@
+import {RuleTester} from 'eslint';
+import {preferThrowIfNoEntry} from './prefer-throw-if-no-entry.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('prefer-throw-if-no-entry', preferThrowIfNoEntry, {
+  valid: [
+    'try { statSync(p, {throwIfNoEntry: false}); } catch {}',
+    'try { fs.statSync(p, {throwIfNoEntry: false}); } catch {}',
+    'try { lstatSync(p, {bigint: true, throwIfNoEntry: false}); } catch {}',
+    "try { statSync(p, {'throwIfNoEntry': false}); } catch {}",
+    "try { statSync(p, {['throwIfNoEntry']: false}); } catch {}",
+    'try { statSync(p, {throwIfNoEntry: true}); } catch {}',
+    'statSync(p);',
+    'fs.statSync(p);',
+    'const s = statSync(p);',
+    'try { JSON.parse(s); } catch {}',
+    'try { otherFn(); } catch {}',
+    'try { otherFn(); } catch { statSync(p); }',
+    'try { try { x(); } catch { statSync(p); } } catch {}',
+    'try { fs.statSync(p); } finally { cleanup(); }',
+    'try { x(); } catch {} finally { statSync(p); }',
+    'try { fstatSync(fd); } catch {}',
+    'try { setTimeout(() => statSync(p), 0); } catch {}',
+    'try { const fn = () => statSync(p); fn(); } catch {}',
+    'try { items.map(item => statSync(item)); } catch {}'
+  ],
+
+  invalid: [
+    {
+      code: 'try { statSync(p); } catch {}',
+      output: null,
+      errors: [
+        {
+          messageId: 'preferThrowIfNoEntry',
+          suggestions: [
+            {
+              messageId: 'addThrowIfNoEntryOption',
+              output: 'try { statSync(p, {throwIfNoEntry: false}); } catch {}'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      code: 'try { fs.statSync(p); } catch {}',
+      output: null,
+      errors: [
+        {
+          messageId: 'preferThrowIfNoEntry',
+          suggestions: [
+            {
+              messageId: 'addThrowIfNoEntryOption',
+              output:
+                'try { fs.statSync(p, {throwIfNoEntry: false}); } catch {}'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      code: 'try { lstatSync(p); } catch {}',
+      output: null,
+      errors: [
+        {
+          messageId: 'preferThrowIfNoEntry',
+          suggestions: [
+            {
+              messageId: 'addThrowIfNoEntryOption',
+              output: 'try { lstatSync(p, {throwIfNoEntry: false}); } catch {}'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      code: 'try { const s = statSync(p); use(s); } catch {}',
+      output: null,
+      errors: [
+        {
+          messageId: 'preferThrowIfNoEntry',
+          suggestions: [
+            {
+              messageId: 'addThrowIfNoEntryOption',
+              output:
+                'try { const s = statSync(p, {throwIfNoEntry: false}); use(s); } catch {}'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      code: 'function f(p) { try { return statSync(p); } catch {} }',
+      output: null,
+      errors: [
+        {
+          messageId: 'preferThrowIfNoEntry',
+          suggestions: [
+            {
+              messageId: 'addThrowIfNoEntryOption',
+              output:
+                'function f(p) { try { return statSync(p, {throwIfNoEntry: false}); } catch {} }'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      code: 'function f(p) { try { return statSync(p).isDirectory(); } catch {} }',
+      output: null,
+      errors: [
+        {
+          messageId: 'preferThrowIfNoEntry',
+          suggestions: [
+            {
+              messageId: 'addThrowIfNoEntryOption',
+              output:
+                'function f(p) { try { return statSync(p, {throwIfNoEntry: false}).isDirectory(); } catch {} }'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      code: 'try { statSync((p)); } catch {}',
+      output: null,
+      errors: [
+        {
+          messageId: 'preferThrowIfNoEntry',
+          suggestions: [
+            {
+              messageId: 'addThrowIfNoEntryOption',
+              output: 'try { statSync((p), {throwIfNoEntry: false}); } catch {}'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      code: 'try { statSync(p, {}); } catch {}',
+      output: null,
+      errors: [
+        {
+          messageId: 'preferThrowIfNoEntry',
+          suggestions: [
+            {
+              messageId: 'addThrowIfNoEntryOption',
+              output: 'try { statSync(p, {throwIfNoEntry: false}); } catch {}'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      code: 'try { statSync(p, {bigint: true}); } catch {}',
+      output: null,
+      errors: [
+        {
+          messageId: 'preferThrowIfNoEntry',
+          suggestions: [
+            {
+              messageId: 'addThrowIfNoEntryOption',
+              output:
+                'try { statSync(p, {bigint: true, throwIfNoEntry: false}); } catch {}'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      code: 'try { statSync(p, options); } catch {}',
+      output: null,
+      errors: [
+        {
+          messageId: 'preferThrowIfNoEntry',
+          suggestions: []
+        }
+      ]
+    },
+    {
+      code: 'try { statSync(...args); } catch {}',
+      output: null,
+      errors: [
+        {
+          messageId: 'preferThrowIfNoEntry',
+          suggestions: []
+        }
+      ]
+    },
+    {
+      code: 'try { if (statSync(p)) doStuff(); } catch {}',
+      output: null,
+      errors: [
+        {
+          messageId: 'preferThrowIfNoEntry',
+          suggestions: [
+            {
+              messageId: 'addThrowIfNoEntryOption',
+              output:
+                'try { if (statSync(p, {throwIfNoEntry: false})) doStuff(); } catch {}'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      code: 'try { try { statSync(p); } catch {} } catch {}',
+      output: null,
+      errors: [
+        {
+          messageId: 'preferThrowIfNoEntry',
+          suggestions: [
+            {
+              messageId: 'addThrowIfNoEntryOption',
+              output:
+                'try { try { statSync(p, {throwIfNoEntry: false}); } catch {} } catch {}'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      code: 'try { statSync(a); lstatSync(b); } catch {}',
+      output: null,
+      errors: [
+        {
+          messageId: 'preferThrowIfNoEntry',
+          suggestions: [
+            {
+              messageId: 'addThrowIfNoEntryOption',
+              output:
+                'try { statSync(a, {throwIfNoEntry: false}); lstatSync(b); } catch {}'
+            }
+          ]
+        },
+        {
+          messageId: 'preferThrowIfNoEntry',
+          suggestions: [
+            {
+              messageId: 'addThrowIfNoEntryOption',
+              output:
+                'try { statSync(a); lstatSync(b, {throwIfNoEntry: false}); } catch {}'
+            }
+          ]
+        }
+      ]
+    }
+  ]
+});

--- a/src/rules/prefer-throw-if-no-entry.ts
+++ b/src/rules/prefer-throw-if-no-entry.ts
@@ -121,14 +121,14 @@ export const preferThrowIfNoEntry: Rule.RuleModule = {
     type: 'suggestion',
     docs: {
       description:
-        'Prefer `{throwIfNoEntry: false}` over catching missing fs entries from sync stat calls',
+        'Prefer `{throwIfNoEntry: false}` over relying on a thrown error for missing fs entries from sync stat calls',
       recommended: false
     },
     hasSuggestions: true,
     schema: [],
     messages: {
       preferThrowIfNoEntry:
-        'Use { throwIfNoEntry: false } and check the return value instead of catching missing fs entries. Creating Error stack traces is expensive.',
+        'Pass { throwIfNoEntry: false } and check the return value for missing entries, keeping the try/catch for real errors like EACCES. Throwing on the common not-found path builds an expensive Error stack trace.',
       addThrowIfNoEntryOption:
         'Pass { throwIfNoEntry: false } so the call returns undefined instead of throwing.'
     }

--- a/src/rules/prefer-throw-if-no-entry.ts
+++ b/src/rules/prefer-throw-if-no-entry.ts
@@ -1,0 +1,157 @@
+import type {Rule, SourceCode} from 'eslint';
+import type {CallExpression, Node} from 'estree';
+
+const STAT_SYNC_NAMES = new Set(['statSync', 'lstatSync']);
+
+function isStatSyncCallee(node: CallExpression): boolean {
+  const callee = node.callee;
+
+  if (callee.type === 'Identifier') {
+    return STAT_SYNC_NAMES.has(callee.name);
+  }
+
+  return (
+    callee.type === 'MemberExpression' &&
+    !callee.computed &&
+    callee.property.type === 'Identifier' &&
+    STAT_SYNC_NAMES.has(callee.property.name)
+  );
+}
+
+function hasThrowIfNoEntryOption(node: CallExpression): boolean {
+  const options = node.arguments[1];
+  if (options?.type !== 'ObjectExpression') {
+    return false;
+  }
+
+  return options.properties.some((property) => {
+    if (property.type !== 'Property') {
+      return false;
+    }
+    if (property.key.type === 'Identifier') {
+      return !property.computed && property.key.name === 'throwIfNoEntry';
+    }
+    return (
+      property.key.type === 'Literal' && property.key.value === 'throwIfNoEntry'
+    );
+  });
+}
+
+function isFunctionLike(node: Node): boolean {
+  return (
+    node.type === 'FunctionDeclaration' ||
+    node.type === 'FunctionExpression' ||
+    node.type === 'ArrowFunctionExpression'
+  );
+}
+
+function isInTryBlockWithCatch(node: Rule.Node): boolean {
+  let child: Rule.Node = node;
+  let parent = node.parent;
+
+  while (parent) {
+    if (isFunctionLike(parent)) {
+      return false;
+    }
+    if (parent.type === 'TryStatement') {
+      if (child === parent.handler || child === parent.finalizer) {
+        return false;
+      }
+      if (child === parent.block && parent.handler) {
+        return true;
+      }
+    }
+    child = parent;
+    parent = parent.parent;
+  }
+
+  return false;
+}
+
+function buildSuggestions(
+  node: CallExpression,
+  sourceCode: SourceCode
+): Rule.SuggestionReportDescriptor[] {
+  if (node.arguments.some((arg) => arg.type === 'SpreadElement')) {
+    return [];
+  }
+
+  if (node.arguments.length === 1) {
+    const closeParen = sourceCode.getLastToken(node);
+    if (!closeParen) {
+      return [];
+    }
+    return [
+      {
+        messageId: 'addThrowIfNoEntryOption',
+        fix: (fixer) =>
+          fixer.insertTextBefore(closeParen, ', {throwIfNoEntry: false}')
+      }
+    ];
+  }
+
+  if (node.arguments.length === 2) {
+    const options = node.arguments[1];
+    if (options?.type !== 'ObjectExpression') {
+      return [];
+    }
+    if (options.properties.length === 0) {
+      return [
+        {
+          messageId: 'addThrowIfNoEntryOption',
+          fix: (fixer) => fixer.replaceText(options, '{throwIfNoEntry: false}')
+        }
+      ];
+    }
+    const lastProperty = options.properties.at(-1)!;
+    return [
+      {
+        messageId: 'addThrowIfNoEntryOption',
+        fix: (fixer) =>
+          fixer.insertTextAfter(lastProperty, ', throwIfNoEntry: false')
+      }
+    ];
+  }
+
+  return [];
+}
+
+export const preferThrowIfNoEntry: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer `{throwIfNoEntry: false}` over catching missing fs entries from sync stat calls',
+      recommended: false
+    },
+    hasSuggestions: true,
+    schema: [],
+    messages: {
+      preferThrowIfNoEntry:
+        'Use { throwIfNoEntry: false } and check the return value instead of catching missing fs entries. Creating Error stack traces is expensive.',
+      addThrowIfNoEntryOption:
+        'Pass { throwIfNoEntry: false } so the call returns undefined instead of throwing.'
+    }
+  },
+  create(context) {
+    const {sourceCode} = context;
+
+    return {
+      CallExpression(node: CallExpression & Rule.NodeParentExtension) {
+        if (
+          !isStatSyncCallee(node) ||
+          hasThrowIfNoEntryOption(node) ||
+          !isInTryBlockWithCatch(node)
+        ) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: 'preferThrowIfNoEntry',
+          suggest: buildSuggestions(node, sourceCode)
+        });
+      }
+    };
+  }
+};


### PR DESCRIPTION
## Summary

- add opt-in `prefer-throw-if-no-entry`
- report `statSync`/`lstatSync` calls inside `try/catch` when they do not pass `{ throwIfNoEntry: false }`
- provide suggestions to add `{ throwIfNoEntry: false }` where the stat options object can be safely edited

## Notes

This is suggestion-only and not part of the recommended config. It skips `try/finally` without `catch`, nested functions, calls that already pass `{ throwIfNoEntry: false }`, and `fstatSync` because file-descriptor stat calls do not have a missing path entry case.

Node `v24.9.0` benchmark for 200,000 missing `statSync` calls:

- try/catch miss path: `679.6ms`
- `{ throwIfNoEntry: false }` miss path: `147.3ms`

## Test plan

- `npm test -- src/rules/prefer-throw-if-no-entry.test.ts`
- `npm run lint`
- `npm run build`