### PR TITLE
fix(prefer-array-to-sorted): handle null Oxlint annotations

### DIFF
--- a/src/rules/prefer-array-to-sorted.ts
+++ b/src/rules/prefer-array-to-sorted.ts
@@ -39,7 +39,7 @@ function getTypeReferenceName(node: TSESTree.Node): string | null {
 
 function hasKnownNonArrayTypeAnnotation(node: TSESTree.BindingName): boolean {
   const typeAnnotation = node.typeAnnotation;
-  if (typeAnnotation === undefined) {
+  if (!typeAnnotation) {
     return false;
   }
 

--- a/src/test/oxlint-integration.test.ts
+++ b/src/test/oxlint-integration.test.ts
@@ -60,4 +60,25 @@ describe('oxlint integration', () => {
 
     expect(output).not.toContain('e18e/prefer-includes');
   });
+
+  it('should run prefer-array-to-sorted without crashing', () => {
+    const invalidFile = join(
+      process.cwd(),
+      'test/fixtures/oxlint/prefer-array-to-sorted.js'
+    );
+
+    try {
+      execSync(`npx oxlint -c "${configPath}" "${invalidFile}"`, {
+        encoding: 'utf-8',
+        cwd: process.cwd()
+      });
+
+      expect.fail('Expected oxlint to report a violation');
+    } catch (error) {
+      const errorObj = error as {stdout: string; stderr: string};
+      const output = errorObj.stdout + errorObj.stderr;
+      expect(output).toContain('e18e(prefer-array-to-sorted)');
+      expect(output).not.toContain('Error running JS plugin');
+    }
+  });
 });

--- a/test/fixtures/oxlint/oxlint.config.json
+++ b/test/fixtures/oxlint/oxlint.config.json
@@ -1,6 +1,7 @@
 {
   "jsPlugins": ["<PLUGIN_PATH>"],
   "rules": {
-    "e18e/prefer-includes": "error"
+    "e18e/prefer-includes": "error",
+    "e18e/prefer-array-to-sorted": "error"
   }
 }

--- a/test/fixtures/oxlint/prefer-array-to-sorted.js
+++ b/test/fixtures/oxlint/prefer-array-to-sorted.js
@@ -1,0 +1,4 @@
+const items = [];
+const sorted = [...items].sort();
+
+console.log(sorted);


### PR DESCRIPTION
Turns out, `prefer-array-to-sorted` crashes under Oxlint when a TypeScript type annotation is `null` rather than `undefined`. Here's a fix, including an Oxlint integration fixture covering the regression.