### PR TITLE
fix(prefer-array-at): guard against more assignment cases where .at(-1) would be illegal

### DIFF
--- a/src/rules/prefer-array-at.test.ts
+++ b/src/rules/prefer-array-at.test.ts
@@ -243,6 +243,59 @@ typedRuleTester.run('prefer-array-at (typed)', preferArrayAt, {
         declare const list: CustomList;
         const last = list[list.length - 1];
       `
+    },
+    {
+      // Direct Assignment
+      code: `
+        const items: number[] = [1];
+        items[items.length - 1]! = 42;
+      `
+    },
+    {
+      // Increment Assignment
+      code: `
+        const items: number[] = [1];
+        items[items.length - 1]! += 42;
+      `
+    },
+    {
+      // For-in Assignment
+      code: `
+        const items: string[] = [''];
+        const source = {key: true};
+        for (items[items.length - 1] in source) {}
+      `
+    },
+    {
+      // For-of Assignment
+      code: `
+        const items: number[] = [1];
+        const source = [2, 3];
+        for (items[items.length - 1] of source) {}
+      `
+    },
+    {
+      // Delete
+      code: `
+        const items: number[] = [1];
+        delete items[items.length - 1];
+      `
+    },
+    {
+      // AssignmentPattern target
+      code: `
+        const items: number[] = [1];
+        const values = [2];
+        [items[items.length - 1] = 0] = values;
+      `
+    },
+    {
+      // RestElement target
+      code: `
+        const items: number[][] = [[]];
+        const values = [1, 2];
+        [...items[items.length - 1]] = values;
+      `
     }
   ],
 
@@ -264,6 +317,26 @@ typedRuleTester.run('prefer-array-at (typed)', preferArrayAt, {
           column: 22,
           endLine: 3,
           endColumn: 41
+        }
+      ]
+    },
+    // Inner indexed assignment
+    {
+      code: `
+        const arr: number[] = [1, 2, 3];
+        arr[arr.length - 1]!.property = value
+      `,
+      output: `
+        const arr: number[] = [1, 2, 3];
+        arr.at(-1)!.property = value
+      `,
+      errors: [
+        {
+          messageId: 'preferAt',
+          line: 3,
+          column: 9,
+          endLine: 3,
+          endColumn: 28
         }
       ]
     },

--- a/src/rules/prefer-array-at.ts
+++ b/src/rules/prefer-array-at.ts
@@ -3,6 +3,32 @@ import {isArrayType, isStringType} from '../utils/typescript.js';
 
 type MessageIds = 'preferAt';
 
+function isWriteTarget(node: TSESTree.Node): boolean {
+  let target = node;
+
+  while (
+    target.parent?.type === 'TSAsExpression' ||
+    target.parent?.type === 'TSNonNullExpression' ||
+    target.parent?.type === 'TSTypeAssertion'
+  ) {
+    target = target.parent;
+  }
+
+  const parent = target.parent;
+
+  return (
+    (parent?.type === 'AssignmentExpression' && parent.left === target) ||
+    (parent?.type === 'UpdateExpression' && parent.argument === target) ||
+    (parent?.type === 'ForInStatement' && parent.left === target) ||
+    (parent?.type === 'ForOfStatement' && parent.left === target) ||
+    (parent?.type === 'AssignmentPattern' && parent.left === target) ||
+    (parent?.type === 'RestElement' && parent.argument === target) ||
+    (parent?.type === 'UnaryExpression' &&
+      parent.operator === 'delete' &&
+      parent.argument === target)
+  );
+}
+
 export const preferArrayAt: TSESLint.RuleModule<MessageIds, []> = {
   meta: {
     type: 'suggestion',
@@ -62,12 +88,7 @@ export const preferArrayAt: TSESLint.RuleModule<MessageIds, []> = {
           return;
         }
 
-        const parent = node.parent;
-        if (
-          parent &&
-          parent.type === 'AssignmentExpression' &&
-          parent.left === node
-        ) {
+        if (isWriteTarget(node)) {
           return;
         }
 


### PR DESCRIPTION
This PR makes the `prefer-array-at` rule more resilient to assignment cases:

1. left-hand assignments
like `items[items.length - 1]! = 42` or `items[items.length - 1]! += 42` are no longer transformed because they would lead to `TS2364`. Note that type assertions and non-null assertions no the target side needed explicit checking. This is what was reported in #148, normal assignments without `!` were already properly checked.

2. for-in and for-of assignments
while uncommon, can lead to `Uncaught ReferenceError: Invalid left-hand side in for-loop`

3. Destructuring
also uncommon, but can lead to `Uncaught SyntaxError: Invalid destructuring assignment target`

4. `delete`
transforming `delete items[items.length - 1]` into `delete items.at(-1)` yields no runtime error, but doesn’t delete anything and is therefore wrong.

fixes #148

---

Note: This PR was created with the help of AI, but a human (me) was always in the loop and no communication was done using AI. I am not a meat proxy.