### PR TITLE
fix: handle parenthesised targets in some rules

### DIFF
--- a/src/rules/no-indexof-equality.test.ts
+++ b/src/rules/no-indexof-equality.test.ts
@@ -353,6 +353,63 @@ ruleTester.run('no-indexof-equality', noIndexOfEquality, {
         if (getName().startsWith("t")) {}
       `,
       errors: [{messageId: 'preferStartsWith', line: 5, column: 13}]
+    },
+
+    // objects which need parentheses when used as the object of a property access
+    {
+      code: `
+        declare const a: string | undefined;
+        declare const b: string;
+        if ((a ?? b).indexOf("t") === 0) {}
+      `,
+      output: `
+        declare const a: string | undefined;
+        declare const b: string;
+        if ((a ?? b).startsWith("t")) {}
+      `,
+      errors: [{messageId: 'preferStartsWith', line: 4, column: 13}]
+    },
+    {
+      code: `
+        declare const a: string[] | undefined;
+        declare const b: string[];
+        if ((a ?? b).indexOf("c") === 2) {}
+      `,
+      output: `
+        declare const a: string[] | undefined;
+        declare const b: string[];
+        if ((a ?? b)[2] === "c") {}
+      `,
+      errors: [
+        {
+          messageId: 'preferDirectAccess',
+          data: {array: '(a ?? b)', item: '"c"', index: '2'},
+          line: 4,
+          column: 13
+        }
+      ]
+    },
+
+    // sequence expression arguments must stay parenthesised
+    {
+      code: `
+        declare const arr: string[];
+        declare const item: string;
+        if (arr.indexOf((item, "c")) === 2) {}
+      `,
+      output: `
+        declare const arr: string[];
+        declare const item: string;
+        if (arr[2] === (item, "c")) {}
+      `,
+      errors: [
+        {
+          messageId: 'preferDirectAccess',
+          data: {array: 'arr', item: '(item, "c")', index: '2'},
+          line: 4,
+          column: 13
+        }
+      ]
     }
   ]
 });

--- a/src/rules/no-indexof-equality.ts
+++ b/src/rules/no-indexof-equality.ts
@@ -1,5 +1,6 @@
 import type {TSESLint, TSESTree} from '@typescript-eslint/utils';
 import {getTypedParserServices} from '../utils/typescript.js';
+import {formatArguments, needsParensForPropertyAccess} from '../utils/ast.js';
 
 type MessageIds = 'preferDirectAccess' | 'preferStartsWith';
 
@@ -69,15 +70,17 @@ export const noIndexOfEquality: TSESLint.RuleModule<MessageIds, []> = {
         }
 
         const objectNode = indexOfCall.callee.object;
-        const searchArg = indexOfCall.arguments[0];
         const type = services.getTypeAtLocation(objectNode as TSESTree.Node);
 
         if (!type) {
           return;
         }
 
-        const objectText = sourceCode.getText(objectNode);
-        const searchText = sourceCode.getText(searchArg);
+        const rawObjectText = sourceCode.getText(objectNode);
+        const objectText = needsParensForPropertyAccess(objectNode)
+          ? `(${rawObjectText})`
+          : rawObjectText;
+        const searchText = formatArguments(indexOfCall.arguments, sourceCode);
         const stringType = checker.getStringType();
 
         if (checker.isTypeAssignableTo(type, stringType)) {

--- a/src/rules/prefer-array-at.test.ts
+++ b/src/rules/prefer-array-at.test.ts
@@ -463,6 +463,28 @@ typedRuleTester.run('prefer-array-at (typed)', preferArrayAt, {
           endColumn: 41
         }
       ]
+    },
+    // Arrays which need parentheses when used as the object of a property access
+    {
+      code: `
+        declare const a: string[] | undefined;
+        declare const b: string[];
+        const last = (a ?? b)[(a ?? b).length - 1];
+      `,
+      output: `
+        declare const a: string[] | undefined;
+        declare const b: string[];
+        const last = (a ?? b).at(-1);
+      `,
+      errors: [
+        {
+          messageId: 'preferAt',
+          line: 4,
+          column: 22,
+          endLine: 4,
+          endColumn: 51
+        }
+      ]
     }
   ]
 });

--- a/src/rules/prefer-array-at.ts
+++ b/src/rules/prefer-array-at.ts
@@ -1,5 +1,6 @@
 import type {TSESLint, TSESTree} from '@typescript-eslint/utils';
 import {isArrayType, isStringType} from '../utils/typescript.js';
+import {needsParensForPropertyAccess} from '../utils/ast.js';
 
 type MessageIds = 'preferAt';
 
@@ -107,7 +108,10 @@ export const preferArrayAt: TSESLint.RuleModule<MessageIds, []> = {
             array: arrayText
           },
           fix(fixer) {
-            return fixer.replaceText(node, `${arrayText}.at(-1)`);
+            const objectText = needsParensForPropertyAccess(node.object)
+              ? `(${arrayText})`
+              : arrayText;
+            return fixer.replaceText(node, `${objectText}.at(-1)`);
           }
         });
       }

--- a/src/rules/prefer-array-from-map.test.ts
+++ b/src/rules/prefer-array-from-map.test.ts
@@ -163,6 +163,18 @@ const b = Array.from(arr2, y => y + 1)`,
           data: {iterable: 'numbers', mapper: 'n => n * 2'}
         }
       ]
+    },
+
+    // sequence expressions must stay parenthesised
+    {
+      code: 'const result = [...(a, items)].map(process)',
+      output: 'const result = Array.from((a, items), process)',
+      errors: [
+        {
+          messageId: 'preferArrayFrom',
+          data: {iterable: '(a, items)', mapper: 'process'}
+        }
+      ]
     }
   ]
 });

--- a/src/rules/prefer-array-from-map.ts
+++ b/src/rules/prefer-array-from-map.ts
@@ -1,5 +1,6 @@
 import type {Rule} from 'eslint';
 import type {CallExpression} from 'estree';
+import {formatArguments} from '../utils/ast.js';
 
 export const preferArrayFromMap: Rule.RuleModule = {
   meta: {
@@ -54,8 +55,11 @@ export const preferArrayFromMap: Rule.RuleModule = {
         }
 
         const spreadElement = arrayExpr.elements[0];
-        const iterableText = sourceCode.getText(spreadElement.argument);
-        const mapperText = sourceCode.getText(node.arguments[0]!);
+        const iterableText = formatArguments(
+          [spreadElement.argument],
+          sourceCode
+        );
+        const mapperText = formatArguments([node.arguments[0]!], sourceCode);
 
         context.report({
           node,

--- a/src/rules/prefer-array-some.test.ts
+++ b/src/rules/prefer-array-some.test.ts
@@ -719,6 +719,114 @@ ruleTester.run('prefer-array-some', preferArraySome, {
           endColumn: 43
         }
       ]
+    },
+
+    // arrays which need parentheses when used as the object of a property access
+    {
+      code: '(a ?? b).filter(fn).length === 0',
+      output: '!(a ?? b).some(fn)',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 33
+        }
+      ]
+    },
+    {
+      code: '(a ?? b).find(fn) === undefined',
+      output: '!(a ?? b).some(fn)',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 32
+        }
+      ]
+    },
+    {
+      code: 'if ((a ?? b).find(fn)) {}',
+      output: 'if ((a ?? b).some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 22
+        }
+      ]
+    },
+    {
+      code: 'if ((a ?? b).filter(fn).length) {}',
+      output: 'if ((a ?? b).some(fn)) {}',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    },
+    {
+      code: '(x ? a : b).filter(fn).length === 0',
+      output: '!(x ? a : b).some(fn)',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 36
+        }
+      ]
+    },
+    {
+      code: 'async function f() { return (await x).filter(fn).length === 0; }',
+      output: 'async function f() { return !(await x).some(fn); }',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 29,
+          endLine: 1,
+          endColumn: 62
+        }
+      ]
+    },
+    {
+      code: '(a, b).filter(fn).length > 0',
+      output: '(a, b).some(fn)',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 29
+        }
+      ]
+    },
+
+    // sequence expression arguments must stay parenthesised
+    {
+      code: 'arr.filter((a, fn)).length === 0',
+      output: '!arr.some((a, fn))',
+      errors: [
+        {
+          messageId: 'preferArraySome',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 33
+        }
+      ]
     }
   ]
 });

--- a/src/rules/prefer-array-some.ts
+++ b/src/rules/prefer-array-some.ts
@@ -11,7 +11,12 @@ import type {
   Node,
   UnaryExpression
 } from 'estree';
-import {isInBooleanContext, isNullish} from '../utils/ast.js';
+import {
+  formatArguments,
+  isInBooleanContext,
+  isNullish,
+  needsParensForPropertyAccess
+} from '../utils/ast.js';
 
 function isIdentifierOrStringLiteral(
   identifierName: string,
@@ -59,10 +64,12 @@ function reportFind(
   }
 
   const sourceCode = context.sourceCode;
-  const arrayText = sourceCode.getText(findCall.callee.object);
-  const argsText = findCall.arguments
-    .map((arg) => sourceCode.getText(arg))
-    .join(', ');
+  const arrayNode = findCall.callee.object;
+  const rawArrayText = sourceCode.getText(arrayNode);
+  const arrayText = needsParensForPropertyAccess(arrayNode)
+    ? `(${rawArrayText})`
+    : rawArrayText;
+  const argsText = formatArguments(findCall.arguments, sourceCode);
 
   const replacement = shouldNegate
     ? `!${arrayText}.some(${argsText})`
@@ -91,10 +98,15 @@ function reportFilterLength(
   }
 
   const sourceCode = context.sourceCode;
-  const arrayText = sourceCode.getText(filterLengthCall.object.callee.object);
-  const argsText = filterLengthCall.object.arguments
-    .map((arg) => sourceCode.getText(arg))
-    .join(', ');
+  const arrayNode = filterLengthCall.object.callee.object;
+  const rawArrayText = sourceCode.getText(arrayNode);
+  const arrayText = needsParensForPropertyAccess(arrayNode)
+    ? `(${rawArrayText})`
+    : rawArrayText;
+  const argsText = formatArguments(
+    filterLengthCall.object.arguments,
+    sourceCode
+  );
 
   const replacement = shouldNegate
     ? `!${arrayText}.some(${argsText})`

--- a/src/rules/prefer-includes.test.ts
+++ b/src/rules/prefer-includes.test.ts
@@ -241,6 +241,30 @@ if (!items.includes(x)) {
       code: 'if (arr.indexOf(item, start) >= 0) {}',
       output: 'if (arr.includes(item, start)) {}',
       errors: [{messageId: 'preferIncludes', line: 1, column: 5}]
+    },
+
+    // arrays which need parentheses when used as the object of a property access
+    {
+      code: '(a ?? b).indexOf(item) === -1',
+      output: '!(a ?? b).includes(item)',
+      errors: [{messageId: 'preferIncludes', line: 1, column: 1}]
+    },
+    {
+      code: '(a ?? b).indexOf(item) !== -1',
+      output: '(a ?? b).includes(item)',
+      errors: [{messageId: 'preferIncludes', line: 1, column: 1}]
+    },
+    {
+      code: 'if ((x ? a : b).indexOf(item) >= 0) {}',
+      output: 'if ((x ? a : b).includes(item)) {}',
+      errors: [{messageId: 'preferIncludes', line: 1, column: 5}]
+    },
+
+    // sequence expression arguments must stay parenthesised
+    {
+      code: 'arr.indexOf((a, item)) === -1',
+      output: '!arr.includes((a, item))',
+      errors: [{messageId: 'preferIncludes', line: 1, column: 1}]
     }
   ]
 });

--- a/src/rules/prefer-includes.ts
+++ b/src/rules/prefer-includes.ts
@@ -5,6 +5,7 @@ import type {
   UnaryExpression,
   Expression
 } from 'estree';
+import {formatArguments, needsParensForPropertyAccess} from '../utils/ast.js';
 
 function isIndexOfCall(node: Expression): node is CallExpression {
   return (
@@ -36,15 +37,16 @@ function reportIndexOf(
   shouldNegate: boolean
 ) {
   const sourceCode = context.sourceCode;
-  const arrayText = sourceCode.getText(
+  const arrayNode =
     indexOfCall.callee.type === 'MemberExpression'
       ? indexOfCall.callee.object
-      : indexOfCall.callee
-  );
+      : indexOfCall.callee;
+  const rawArrayText = sourceCode.getText(arrayNode);
+  const arrayText = needsParensForPropertyAccess(arrayNode)
+    ? `(${rawArrayText})`
+    : rawArrayText;
 
-  const argsText = indexOfCall.arguments
-    .map((arg) => sourceCode.getText(arg))
-    .join(', ');
+  const argsText = formatArguments(indexOfCall.arguments, sourceCode);
 
   const replacement = shouldNegate
     ? `!${arrayText}.includes(${argsText})`

--- a/src/utils/ast.ts
+++ b/src/utils/ast.ts
@@ -235,6 +235,9 @@ export function formatArguments(
     return '';
   }
   return args
-    .map((arg) => (sourceCode as SourceCode).getText(arg as Node))
+    .map((arg) => {
+      const text = (sourceCode as SourceCode).getText(arg as Node);
+      return arg.type === 'SequenceExpression' ? `(${text})` : text;
+    })
     .join(', ');
 }


### PR DESCRIPTION
This changes a few rules to check if the target object needs parentheses during
fixing.

For example, `a ?? b` needs to become `(a ?? b)` in order for us to access
methods on it like `(a ?? b).some(fn)`.
